### PR TITLE
Feature/better deduplicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,22 @@ combination of the `append` and `prepend` options.
 **`steps.<name>.(reduce|flatmap).deduplicate`** **object** or
 **null**, a function that removes duplicate events from vectors.
 
+**`steps.<name>.(reduce|flatmap).deduplicate.consider-name`** optional
+**boolean**, defaults to `true`, indicates whether deduplication
+should consider the name of events.
+
+**`steps.<name>.(reduce|flatmap).deduplicate.consider-data`** optional
+**boolean**, defaults to `true`, indicates whether deduplication
+should consider the data contained in events.
+
+**`steps.<name>.(reduce|flatmap).deduplicate.consider-trace`**
+optional **boolean**, defaults to `false`, indicates whether
+deduplication should consider the trace of events.
+
+Setting all three of these to `false` is equivalent to using the
+below-explained `keep` with value `1`, that is, dropping all events
+from each group except for the first one.
+
 #### `keep`
 
 **`steps.<name>.(reduce|flatmap).keep`** **number** or **string**, a

--- a/__tests__/step-functions/deduplicate.ts
+++ b/__tests__/step-functions/deduplicate.ts
@@ -25,3 +25,32 @@ test("Deduplicate works as expected", async () => {
   // Assert
   expect(output.map((e) => e.data)).toEqual([3.14, 3.141, 3.1415]);
 });
+
+test("Deduplicate can consider specific parts of events", async () => {
+  // Arrange
+  const channel = await make("irrelevant", "irrelevant", {
+    "consider-name": false,
+    "consider-data": true,
+    "consider-trace": false,
+  });
+  const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
+  const events = [
+    await makeEvent("a", 3.14, trace),
+    await makeEvent("b", 3.14, trace),
+    await makeEvent("c", 3.141, trace),
+    await makeEvent("d", 3.14, trace),
+    await makeEvent("e", 3.14, trace),
+    await makeEvent("f", 3.141, trace),
+    await makeEvent("g", 3.14, trace),
+    await makeEvent("h", 3.1415, trace),
+  ];
+  // Act
+  channel.send(events);
+  const [output] = await Promise.all([
+    consume(channel.receive),
+    channel.close(),
+  ]);
+  // Assert
+  expect(output.map((e) => e.data)).toEqual([3.14, 3.141, 3.1415]);
+  expect(output.map((e) => e.name)).toEqual(["a", "c", "h"]);
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -233,17 +233,30 @@ const renameFunctionTemplateSchema = {
 
 /**
  * A `deduplicate` function removes event duplicates from the batches
- * it receives.
+ * it receives, considering various pieces of the events.
  */
 interface DeduplicateFunctionTemplate {
-  deduplicate: Record<string, never> | null;
+  deduplicate: {
+    ["consider-name"]?: boolean;
+    ["consider-data"]?: boolean;
+    ["consider-trace"]?: boolean;
+  } | null;
 }
 const deduplicateFunctionTemplateSchema = {
   type: "object",
   properties: {
     deduplicate: {
       anyOf: [
-        { type: "object", properties: {}, additionalProperties: false },
+        {
+          type: "object",
+          properties: {
+            "consider-name": { type: "boolean" },
+            "consider-data": { type: "boolean" },
+            "consider-trace": { type: "boolean" },
+          },
+          additionalProperties: false,
+          required: [],
+        },
         { type: "null" },
       ],
     },
@@ -1000,7 +1013,7 @@ export const runPipeline = async (
     for await (const event of connectedChannel.receive) {
       // `event` already went through the whole pipeline.
       pipelineEvents.inc({ flow: "out" }, 1);
-      logger.debug("Event", event.signature, "reached the end of the pipeline");
+      logger.debug("Event", event.id, "reached the end of the pipeline");
     }
     logger.debug("Finished pipeline operation");
     await stopExposingMetrics();

--- a/src/conf.ts
+++ b/src/conf.ts
@@ -126,7 +126,7 @@ export const METRICS_NAME_PREFIX: string =
  * The timeout used for emitted HTTP requests.
  */
 export const HTTP_CLIENT_TIMEOUT: number = parseInt(
-  process.env.HTTP_CLIENT_TIMEOUT ?? "60000",
+  process.env.HTTP_CLIENT_TIMEOUT ?? "60", // 60 seconds
   10
 );
 

--- a/src/io/axios.ts
+++ b/src/io/axios.ts
@@ -11,7 +11,7 @@ import {
  * The axios instance used to emit all http requests.
  */
 export const axiosInstance = axios.create({
-  timeout: HTTP_CLIENT_TIMEOUT,
+  timeout: HTTP_CLIENT_TIMEOUT * 1000,
   httpAgent: new HttpAgent(),
   httpsAgent: new HttpsAgent({
     rejectUnauthorized: HTTP_CLIENT_REJECT_UNAUTHORIZED,

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -162,7 +162,7 @@ export const run = async (pipeline: Pipeline): Promise<Step> => {
       // Send the event to the bus queue.
       return events.forEach((event) => {
         if (!busQueue.push([index, event])) {
-          logger.debug("Couldn't catch event", event.signature, "in bus queue");
+          logger.debug("Couldn't catch event", event.id, "in bus queue");
           deadEvents.push(event);
           deadEventsMetric.set(deadEvents.length);
         }
@@ -182,7 +182,7 @@ export const run = async (pipeline: Pipeline): Promise<Step> => {
       const nextNodeIndices = edges.get(sourceNodeIndex) ?? [];
       logger.debug(
         "Got event",
-        event.signature,
+        event.id,
         "from the bus queue, emitted from node:",
         sourceNodeIndex,
         "; next nodes are:",
@@ -202,7 +202,7 @@ export const run = async (pipeline: Pipeline): Promise<Step> => {
       if (!sent) {
         logger.debug(
           "Couldn't forward event",
-          event.signature,
+          event.id,
           "to at least one node in",
           nextNodeIndices
         );

--- a/src/step-functions/deduplicate.ts
+++ b/src/step-functions/deduplicate.ts
@@ -1,4 +1,5 @@
 import { Channel, AsyncQueue, flatMap } from "../async-queue";
+import { getSignature } from "../utils";
 import { Event } from "../event";
 
 /**
@@ -6,18 +7,28 @@ import { Event } from "../event";
  * removed are never the first ones encountered for each event
  * identity.
  *
+ * @param keyFn Async function that produces event identities for
+ * deduplication.
  * @param events Vector of events to remove duplicates from.
- * @returns A new vector of events.
+ * @returns A promise that resolves to a new vector of events.
  */
-const deduplicate = (events: Event[]): Event[] => {
+const deduplicate = async (
+  keyFn: (e: Event) => Promise<string>,
+  events: Event[]
+): Promise<Event[]> => {
   const signatures = new Set<string>();
-  return events.filter((event) => {
-    if (signatures.has(event.signature)) {
-      return false;
-    }
-    signatures.add(event.signature);
-    return true;
-  });
+  const signed = await Promise.all(
+    events.map((e) => keyFn(e).then((signature) => ({ e, signature })))
+  );
+  return signed
+    .filter(({ signature }) => {
+      if (signatures.has(signature)) {
+        return false;
+      }
+      signatures.add(signature);
+      return true;
+    })
+    .map(({ e }) => e);
 };
 
 /**
@@ -26,20 +37,56 @@ const deduplicate = (events: Event[]): Event[] => {
  * @param pipelineName The name of the pipeline.
  * @param pipelineSignature The signature of the pipeline.
  * @param options The options that indicate how to deduplicate
- * events. This argument is actually ignored, since currently there
- * are no options available.
+ * events.
  * @returns A channel that removes event duplicates.
  */
 export const make = async (
   /* eslint-disable @typescript-eslint/no-unused-vars */
   pipelineName: string,
   pipelineSignature: string,
-  options: Record<string, never> | null
   /* eslint-enable @typescript-eslint/no-unused-vars */
+  options: {
+    ["consider-name"]?: boolean;
+    ["consider-data"]?: boolean;
+    ["consider-trace"]?: boolean;
+  } | null
 ): Promise<Channel<Event[], Event>> => {
   const queue = new AsyncQueue<Event[]>();
+  const key = [
+    options?.["consider-name"] ?? true ? "1" : "0",
+    options?.["consider-data"] ?? true ? "1" : "0",
+    options?.["consider-trace"] ?? false ? "1" : "0",
+  ].join("");
+  let keyFn: (e: Event) => Promise<string>;
+  switch (key) {
+    case "000":
+      keyFn = async () => "1"; // Constant key: all events are considered equal.
+      break;
+    case "001":
+      keyFn = (e: Event) => getSignature(e.trace);
+      break;
+    case "010":
+      keyFn = (e: Event) => getSignature(e.data);
+      break;
+    case "011":
+      keyFn = (e: Event) => getSignature(e.data, e.trace);
+      break;
+    case "100":
+      keyFn = async (e: Event) => e.name;
+      break;
+    case "101":
+      keyFn = (e: Event) => getSignature(e.name, e.trace);
+      break;
+    case "110":
+      keyFn = (e: Event) => getSignature(e.name, e.data);
+      break;
+    case "111":
+    default:
+      keyFn = (e: Event) => getSignature(e.name, e.data, e.trace);
+      break;
+  }
   return flatMap(
-    (events: Event[]) => Promise.resolve(deduplicate(events)),
+    (events: Event[]) => deduplicate(keyFn, events),
     queue.asChannel()
   );
 };


### PR DESCRIPTION
This PR improves the `deduplicate` step function by providing the user the option to select which event fields to consider as each event's identity. For example:

```yaml
name: "Better deduplicate"
input:
  stdin:
steps:
  foo:
    window:
      events: 100
      seconds: 5
    reduce:
      deduplicate:
        consider-name: false
        consider-data: true
        consider-trace: false

```

Shows a pipeline with a single deduplication step that ignores each event's name and trace during deduplication.

The new options available are `consider-name`, `consider-data` and `consider-trace` with default values `true`, `true` and `false` respectively.