### PR TITLE
Feature/fix signature collision

### DIFF
--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -29,6 +29,15 @@ test("Signatures can't be generated for non JSON-encodable things", async () => 
   await expect(utils.getSignature(undefined)).rejects.toThrow();
 });
 
+test("Signatures are distinct", async () => {
+  const s1 = await utils.getSignature("foo", "bar");
+  const s2 = await utils.getSignature("foobar");
+  const s3 = await utils.getSignature("foo", undefined, "bar");
+  expect(s1).not.toEqual(s2);
+  expect(s1).not.toEqual(s3);
+  expect(s2).not.toEqual(s3);
+});
+
 test("Loggers can be created according to the current log level", () => {
   // Assumes the current log level is 'error'.
   // This tests uses the fact that the null logger functions return

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,9 +32,9 @@ export const getSignature = (...args: unknown[]): Promise<string> =>
     hash.on("error", reject);
     try {
       args
-        .filter((arg) => typeof arg !== "undefined")
-        .map((arg) => (typeof arg === "string" ? arg : JSON.stringify(arg)))
-        .forEach((arg) => hash.write(arg));
+        .map((arg, index) => ({ arg, index }))
+        .filter(({ arg }) => typeof arg !== "undefined")
+        .forEach((arg) => hash.write(JSON.stringify(arg)));
     } catch (err) {
       reject(err);
     } finally {


### PR DESCRIPTION
This PR fixes a glaring error with signature generation when requested for several arguments, which was producing identical signatures for different arguments (not related to the SHA-1 hashing). A test is also included that checks those cases.