### PR TITLE
Feature/HTTP improvements

### DIFF
--- a/__tests__/io/http-client.ts
+++ b/__tests__/io/http-client.ts
@@ -1,0 +1,57 @@
+// Mock the axios instance.
+/* eslint-disable @typescript-eslint/no-unused-vars */
+const mockRequest = jest.fn();
+/* eslint-enable @typescript-eslint/no-unused-vars */
+jest.mock("../../src/io/axios", () => {
+  const originalModule = jest.requireActual("../../src/io/axios");
+  return {
+    ...originalModule,
+    axiosInstance: { request: mockRequest },
+  };
+});
+afterEach(() => mockRequest.mockClear());
+
+import { HTTP_CLIENT_MAX_RETRIES } from "../../src/conf";
+import { request } from "../../src/io/http-client";
+
+class TestError extends Error {
+  response: object;
+  constructor(message: string, response: object) {
+    super(message);
+    this.response = response;
+  }
+}
+
+test("Request retrying works for all attempts", async () => {
+  // Arrange
+  mockRequest.mockImplementation(() =>
+    Promise.reject(new TestError("test error", { status: 503 }))
+  );
+  // Act & assert
+  await expect(request({ url: "whatever" })).rejects.toThrow("test error");
+  expect(mockRequest).toHaveBeenCalledTimes(HTTP_CLIENT_MAX_RETRIES + 1);
+});
+
+test("Request retrying only works on 5xx status codes", async () => {
+  // Arrange
+  mockRequest.mockImplementation(() =>
+    Promise.reject(new TestError("test error", { status: 400 }))
+  );
+  // Act & assert
+  await expect(request({ url: "whatever" })).rejects.toThrow("test error");
+  expect(mockRequest).toHaveBeenCalledTimes(1);
+});
+
+test("Request retrying can rescueue a request", async () => {
+  // Arrange
+  mockRequest
+    .mockImplementationOnce(() =>
+      Promise.reject(new TestError("test error", { status: 500 }))
+    )
+    .mockImplementationOnce(() => Promise.resolve({ data: "blagoblags" }));
+  // Act
+  const response = await request({ url: "whatever" });
+  // Assert
+  expect(response).toEqual({ data: "blagoblags" });
+  expect(mockRequest).toHaveBeenCalledTimes(2);
+});

--- a/__tests__/step-functions/send-http.ts
+++ b/__tests__/step-functions/send-http.ts
@@ -40,7 +40,7 @@ test("Send-http works as expected", async () => {
   expect(mockRequest.mock.calls[0][0].method).toEqual(method);
   expect(mockRequest.mock.calls[0][0].data).toEqual(events);
   expect(mockRequest.mock.calls[0][0].headers).toEqual({
-    "Content-Type": "application/x-ndjson",
+    "content-type": "application/x-ndjson",
   });
 });
 
@@ -68,7 +68,7 @@ test("Send-http works when specifying a target plainly", async () => {
   expect(mockRequest.mock.calls[0][0].method).toEqual(method);
   expect(mockRequest.mock.calls[0][0].data).toEqual(events);
   expect(mockRequest.mock.calls[0][0].headers).toEqual({
-    "Content-Type": "application/x-ndjson",
+    "content-type": "application/x-ndjson",
   });
 });
 
@@ -101,13 +101,13 @@ test("Send-http works when specifying a jq expression and headers", async () => 
   expect(mockRequest.mock.calls[0][0].method).toEqual(method);
   expect(mockRequest.mock.calls[0][0].data).toEqual("hello");
   expect(mockRequest.mock.calls[0][0].headers).toEqual({
-    "Content-Type": "text/plain",
+    "content-type": "text/plain",
   });
   expect(mockRequest.mock.calls[1]).toHaveLength(1);
   expect(mockRequest.mock.calls[1][0].url).toEqual(target);
   expect(mockRequest.mock.calls[1][0].method).toEqual(method);
   expect(mockRequest.mock.calls[1][0].data).toEqual("world");
   expect(mockRequest.mock.calls[1][0].headers).toEqual({
-    "Content-Type": "text/plain",
+    "content-type": "text/plain",
   });
 });

--- a/__tests__/step-functions/send-receive-http.ts
+++ b/__tests__/step-functions/send-receive-http.ts
@@ -44,7 +44,7 @@ test("Send-receive-http works as expected", async () => {
   expect(mockRequest.mock.calls[0][0].method).toEqual(method);
   expect(mockRequest.mock.calls[0][0].data).toEqual(events);
   expect(mockRequest.mock.calls[0][0].headers).toEqual({
-    "Content-Type": "application/x-ndjson",
+    "content-type": "application/x-ndjson",
   });
 });
 
@@ -83,6 +83,6 @@ test("Send-receive-http works when using jq as intermediary", async () => {
     events.map((e) => e.toJSON()).map((e) => ({ ...e, n: "changed" }))
   );
   expect(mockRequest.mock.calls[0][0].headers).toEqual({
-    "Content-Type": "application/json",
+    "content-type": "application/json",
   });
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -459,7 +459,7 @@ interface ExposeHTTPFunctionTemplate {
     endpoint: string;
     port: number | string;
     responses: number | string;
-    headers?: { [key: string]: string | number | boolean };
+    headers?: { [key: string]: string | string[] };
     ["jq-expr"]?: string;
   };
 }
@@ -488,8 +488,7 @@ const exposeHTTPFunctionTemplateSchema = {
           additionalProperties: {
             anyOf: [
               { type: "string" },
-              { type: "number" },
-              { type: "boolean" },
+              { type: "array", items: { type: "string" } },
             ],
           },
         },

--- a/src/conf.ts
+++ b/src/conf.ts
@@ -152,3 +152,24 @@ export const HTTP_CLIENT_MAX_CONTENT_LENGTH: number = parseInt(
   process.env.HTTP_CLIENT_MAX_CONTENT_LENGTH ?? "52428800", // 50 MiB
   10
 );
+
+/**
+ * The maximum number of additional request attempts for each HTTP
+ * response received with status 5xx.
+ */
+export const HTTP_CLIENT_MAX_RETRIES: number = parseInt(
+  process.env.HTTP_CLIENT_MAX_RETRIES ?? "4",
+  10
+);
+
+/**
+ * The constant factor used in HTTP requests exponential backoff, in
+ * seconds.
+ */
+export const HTTP_CLIENT_BACKOFF_FACTOR: number = Math.max(
+  parseInt(
+    process.env.HTTP_CLIENT_BACKOFF_FACTOR ?? (NODE_ENV === "test" ? "0" : "1"), // 1 second
+    10
+  ),
+  0
+);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -145,3 +145,26 @@ export const envsubst = (thing: unknown): unknown => {
     return thing;
   }
 };
+
+/**
+ * Merges HTTP headers as given, preserving the last ones in case of
+ * collision. This procedure ignores capitalization in header keys,
+ * and assumes that each header set given doesn't contain collisions
+ * within. If they do, the keys remaining in the result are chosen
+ * arbitrarily.
+ *
+ * @param headers The headers to merge.
+ * @returns The merged headers.
+ */
+export const mergeHeaders = <T>(
+  ...headers: Record<string, T>[]
+): Record<string, T> =>
+  headers.reduce(
+    (merged, h) => ({
+      ...merged,
+      ...Object.fromEntries(
+        Object.entries(h).map(([k, v]) => [k.toLowerCase(), v])
+      ),
+    }),
+    {}
+  );


### PR DESCRIPTION
This PR improves HTTP operations slightly by adding:
1. Retries for `send-http` and `send-receive-http`, in case a 5xx response is received.
1. Proper merging of HTTP headers when giving the user the option to provide some, while some others are not open for alteration. Previously the HTTP merging didn't consider capitalization differences.