### PR TITLE
Feature/redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,16 +277,32 @@ receiving data are one of
 [`brpop`](https://redis.io/commands/brpop/) for each of the
 corresponding redis commands.
 
-**`input.redis.url`** required **string** or **list of string**, a URL
-of list of URLs to connect to. If a list is given, a redis cluster is
-assumed.
+**`input.redis.instance`** optional **string** or **object**,
+parameters required to connect to a single redis instance. If using a
+plain string, it must match the same restrictions as the `path`
+parameter described below.
 
-**`input.redis.address-map`** optional **object** with keys and values
-being addresses that should get translated when using a
-private-network redis cluster. Keys will be private addresses and
-values will be client-accesible addresses. This is useful for e.g. AWS
-Elasticache as explained
-[here](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/accessing-elasticache.html).
+**`input.redis.instance.path`** required **string**, a redis
+URL. Check te [ioredis
+documentation](https://github.com/luin/ioredis#connect-to-redis) for
+details.
+
+**`input.redis.instance.options`** optional **object**, connection
+options as given to the ioredis library.
+
+**`input.redis.cluster`** optional **list of ClusterNode** or
+**object**, parameters required to connect to a redis cluster. If
+using a list of cluster nodes, they must match the same restrictions
+as the `nodes` parameter described below.
+
+**`input.redis.cluster.nodes`** required **list of ClusterNode**, a
+list of nodes to connect to initially. Check te [ioredis
+documentation](https://github.com/luin/ioredis#cluster) for details.
+
+**`input.redis.cluster.options`** optional **object**, connection
+options as given to the ioredis library.
+
+One of `input.redis.instance` or `input.redis.cluster` must be used.
 
 **`input.redis.subscribe`** optional **string** or **list of string**,
 the channel key or keys to subscribe to if using `subscribe`.
@@ -300,6 +316,9 @@ key or keys to pop items from if using `blpop`.
 
 **`input.redis.brpop`** optional **string** or **list of string**, the
 key or keys to pop items from if using `brpop`.
+
+One of the modes `subscribe`, `psubscribe`, `blpop` and `brpop` must
+be used.
 
 **`input.redis.wrap`** optional **string** or **object**, a wrapping
 directive which specifies that incoming data is not encoded events,
@@ -606,6 +625,68 @@ altered.
 **number** or **string**, the maximum amount of concurrent HTTP
 requests for the step. If omitted, it is set to the value of the
 `HTTP_CLIENT_DEFAULT_CONCURRENCY` environment variable or `10`.
+
+#### `send-redis`
+
+**`steps.<name>.(reduce|flatmap).send-redis`** **object**, a function
+that always sends forward the events in the vectors it receives,
+unmodified. It also sends those vectors to the specified redis
+instance or cluster.
+
+**`steps.<name>.(reduce|flatmap).send-redis.instance`** optional
+**string** or **object**, parameters required to connect to a single
+redis instance. If using a plain string, it must match the same
+restrictions as the `path` parameter described below.
+
+**`steps.<name>.(reduce|flatmap).send-redis.instance.path`** required
+**string**, a redis URL. Check te [ioredis
+documentation](https://github.com/luin/ioredis#connect-to-redis) for
+details.
+
+**`steps.<name>.(reduce|flatmap).send-redis.instance.options`**
+optional **object**, connection options as given to the ioredis
+library.
+
+**`steps.<name>.(reduce|flatmap).send-redis.cluster`** optional **list
+of ClusterNode** or **object**, parameters required to connect to a
+redis cluster. If using a list of cluster nodes, they must match the
+same restrictions as the `nodes` parameter described below.
+
+**`steps.<name>.(reduce|flatmap).send-redis.cluster.nodes`** required
+**list of ClusterNode**, a list of nodes to connect to
+initially. Check te [ioredis
+documentation](https://github.com/luin/ioredis#cluster) for details.
+
+**`steps.<name>.(reduce|flatmap).send-redis.cluster.options`**
+optional **object**, connection options as given to the ioredis
+library.
+
+One of `instance` or `cluster` must be used.
+
+**`steps.<name>.(reduce|flatmap).send-redis.publish`** optional
+**string** denoting the step function will forward events using the
+PUBLISH command to a channel, specified by the value given. The
+PUBLISH command is issued once for every event received.
+
+**`steps.<name>.(reduce|flatmap).send-redis.rpush`** optional
+**string** denoting the step function will forward events using the
+RPUSH command to a key, specified by the value given. The RPUSH
+command is issued once for every vector received.
+
+**`steps.<name>.(reduce|flatmap).send-redis.lpush`** optional
+**string** denoting the step function will forward events using the
+LPUSH command to a key, specified by the value given. The LPUSH
+command is issued once for every vector received.
+
+One of `publish`, `rpush` or `lpush` must be used.
+
+**`steps.<name>.(reduce|flatmap).send-redis.jq-expr`** optional
+**string**, specifies a `jq` filter to apply before forwarding
+events. If using a `jq` filter with `rpush` or `lpush`, the results of
+the filter will always be mapped on to different invocations of the
+corresponding command. This means that a trivial filter like `.` can
+be used to store lists of events instead of plain events in each
+element of a redis list.
 
 #### `expose-http`
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ incoming data as plain text, not JSON.
 
 **`input.poll`** **object** or **string**, the input form that makes a
 pipeline actively fetch data periodically from a remote source using
-HTTP requests.. If given as a string, it indicates the URI of the
+HTTP requests. If given as a string, it indicates the URI of the
 remote event source.
 
 **`input.poll.target`** required **string**, the target URI to use for
@@ -264,6 +264,51 @@ and thus should be wrapped.
 events that wrap the input data.
 
 **`input.poll.wrap.raw`** optional **boolean**, whether to treat
+incoming data as plain text, not JSON.
+
+#### `redis`
+
+**`input.redis`** **object**, the input form that makes the pipeline
+receive data from a redis instance or cluster. The options for
+receiving data are one of
+[`subscribe`](https://redis.io/commands/subscribe/),
+[`psubscribe`](https://redis.io/commands/psubscribe/),
+[`blpop`](https://redis.io/commands/blpop/) or
+[`brpop`](https://redis.io/commands/brpop/) for each of the
+corresponding redis commands.
+
+**`input.redis.url`** required **string** or **list of string**, a URL
+of list of URLs to connect to. If a list is given, a redis cluster is
+assumed.
+
+**`input.redis.address-map`** optional **object** with keys and values
+being addresses that should get translated when using a
+private-network redis cluster. Keys will be private addresses and
+values will be client-accesible addresses. This is useful for e.g. AWS
+Elasticache as explained
+[here](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/accessing-elasticache.html).
+
+**`input.redis.subscribe`** optional **string** or **list of string**,
+the channel key or keys to subscribe to if using `subscribe`.
+
+**`input.redis.psubscribe`** optional **string** or **list of
+string**, the channel pattern or patterns to subscribe to if using
+`psubscribe`.
+
+**`input.redis.blpop`** optional **string** or **list of string**, the
+key or keys to pop items from if using `blpop`.
+
+**`input.redis.brpop`** optional **string** or **list of string**, the
+key or keys to pop items from if using `brpop`.
+
+**`input.redis.wrap`** optional **string** or **object**, a wrapping
+directive which specifies that incoming data is not encoded events,
+and thus should be wrapped.
+
+**`input.redis.wrap.name`** required **string**, the name given to the
+events that wrap the input data.
+
+**`input.redis.wrap.raw`** optional **boolean**, whether to treat
 incoming data as plain text, not JSON.
 
 #### Wrapping

--- a/__tests__/api.ts
+++ b/__tests__/api.ts
@@ -14,7 +14,7 @@ afterEach(() => {
   mockedConsoleLog.mockRestore();
 });
 
-test("Pipeline template construction works normally", () => {
+test("@standalone Pipeline template construction works normally", () => {
   // Arrange
   const raw = {
     name: "Test",
@@ -45,7 +45,7 @@ test("Pipeline template construction works normally", () => {
   expect(() => makePipelineTemplate(raw)).not.toThrow();
 });
 
-test("Pipeline template construction works on empty pipelines", () => {
+test("@standalone Pipeline template construction works on empty pipelines", () => {
   // Arrange
   const raw = {
     name: "Test",
@@ -55,7 +55,7 @@ test("Pipeline template construction works on empty pipelines", () => {
   expect(() => makePipelineTemplate(raw)).not.toThrow();
 });
 
-test("Pipeline template construction accepts extra keys at the root", () => {
+test("@standalone Pipeline template construction accepts extra keys at the root", () => {
   // Arrange
   const raw = {
     name: "Test",
@@ -66,7 +66,7 @@ test("Pipeline template construction accepts extra keys at the root", () => {
   expect(() => makePipelineTemplate(raw)).not.toThrow();
 });
 
-test("Functions must use exactly one of flatmap or reduce", () => {
+test("@standalone Functions must use exactly one of flatmap or reduce", () => {
   // Arrange
   const missingBoth = {
     name: "Test",
@@ -95,7 +95,7 @@ test("Functions must use exactly one of flatmap or reduce", () => {
   expect(() => makePipelineTemplate(correct)).not.toThrow();
 });
 
-test("The function keep-when must hold a valid schema", () => {
+test("@standalone The function keep-when must hold a valid schema", () => {
   // Arrange
   const invalidRaw = {
     name: "Test",
@@ -116,7 +116,7 @@ test("The function keep-when must hold a valid schema", () => {
   expect(() => makePipelineTemplate(validRaw)).not.toThrow();
 });
 
-test("Stopping a pipeline drains the events", async () => {
+test("@standalone Stopping a pipeline drains the events", async () => {
   // Arrange
   const rawTemplate = {
     name: "Test",

--- a/__tests__/async-queue.ts
+++ b/__tests__/async-queue.ts
@@ -1,7 +1,7 @@
 import { consume } from "./test-utils";
 import { AsyncQueue, flatMap, compose } from "../src/async-queue";
 
-test("Shifting from an empty queue blocks", async () => {
+test("@standalone Shifting from an empty queue blocks", async () => {
   // Arrange
   const queue = new AsyncQueue<boolean>();
   // Act
@@ -13,7 +13,7 @@ test("Shifting from an empty queue blocks", async () => {
   expect(blocked).toBe(true);
 });
 
-test("Shifting from a non-empty queue doesn't block", async () => {
+test("@standalone Shifting from a non-empty queue doesn't block", async () => {
   // Arrange
   const queue = new AsyncQueue<boolean>();
   // Act
@@ -26,7 +26,7 @@ test("Shifting from a non-empty queue doesn't block", async () => {
   expect(blocked).toBe(false);
 });
 
-test("A blocked queue can be unblocked by pushing", async () => {
+test("@standalone A blocked queue can be unblocked by pushing", async () => {
   // Arrange
   const queue = new AsyncQueue<null>();
   let blocked = true;
@@ -40,7 +40,7 @@ test("A blocked queue can be unblocked by pushing", async () => {
   expect(blocked).toBe(false);
 });
 
-test("An unblocked queue can be blocked by draining", async () => {
+test("@standalone An unblocked queue can be blocked by draining", async () => {
   // Arrange
   const queue = new AsyncQueue<boolean>();
   // Act & assert
@@ -57,7 +57,7 @@ test("An unblocked queue can be blocked by draining", async () => {
   expect(blocked).toBe(true);
 });
 
-test("A queue can be iterated over, and will yield until it's closed", async () => {
+test("@standalone A queue can be iterated over, and will yield until it's closed", async () => {
   // Arrange
   const queue = new AsyncQueue<number>();
   const valueCount = 7;
@@ -78,7 +78,7 @@ test("A queue can be iterated over, and will yield until it's closed", async () 
   expect(values).toEqual(Array.from({ length: valueCount }, (_, i) => i));
 });
 
-test("Closing a queue prevents pushes", async () => {
+test("@standalone Closing a queue prevents pushes", async () => {
   // Arrange
   const queue = new AsyncQueue<number>();
   const pushedValues = [1, 2, 3];
@@ -96,7 +96,7 @@ test("Closing a queue prevents pushes", async () => {
   expect(remainderValues).toEqual([]);
 });
 
-test("A queue can be used as a channel", async () => {
+test("@standalone A queue can be used as a channel", async () => {
   // Arrange
   const queue = new AsyncQueue<number>();
   // Act
@@ -111,7 +111,7 @@ test("A queue can be used as a channel", async () => {
   expect(third).toEqual(3);
 });
 
-test("A queue's drain promise won't resolve if the queue isn't closed", async () => {
+test("@standalone A queue's drain promise won't resolve if the queue isn't closed", async () => {
   // Arrange
   const queue = new AsyncQueue<boolean>();
   let drained;
@@ -129,7 +129,7 @@ test("A queue's drain promise won't resolve if the queue isn't closed", async ()
   expect(drained).toBe(true);
 });
 
-test("Channels can be composed with the compose combinator", async () => {
+test("@standalone Channels can be composed with the compose combinator", async () => {
   // Arrange
   const firstQueue = new AsyncQueue<number>();
   const firstChannel = flatMap(async (x) => [x * x], firstQueue.asChannel());

--- a/__tests__/input/generator.ts
+++ b/__tests__/input/generator.ts
@@ -2,7 +2,7 @@ import { make } from "../../src/input/generator";
 import { resolveAfter } from "../../src/utils";
 import { consume } from "../test-utils";
 
-test("The generator input form works as expected", async () => {
+test("@standalone The generator input form works as expected", async () => {
   // Arrange
   const [channel] = make("irrelevant", "irrelevant", {
     name: "test",

--- a/__tests__/input/http.ts
+++ b/__tests__/input/http.ts
@@ -3,7 +3,7 @@ import { make } from "../../src/input/http";
 import { resolveAfter } from "../../src/utils";
 import { consume } from "../test-utils";
 
-test("The http input form works as expected", async () => {
+test("@standalone The http input form works as expected", async () => {
   // Arrange
   const [channel] = make("irrelevant", "irrelevant", {
     endpoint: "/events",

--- a/__tests__/input/poll.ts
+++ b/__tests__/input/poll.ts
@@ -20,7 +20,7 @@ import { make } from "../../src/input/poll";
 import { resolveAfter } from "../../src/utils";
 import { consume } from "../test-utils";
 
-test("The poll input form works as expected", async () => {
+test("@standalone The poll input form works as expected", async () => {
   // Arrange
   const [channel] = make("irrelevant", "irrelevant", {
     target: "http://non-existent.org",

--- a/__tests__/input/redis.ts
+++ b/__tests__/input/redis.ts
@@ -1,0 +1,121 @@
+import Redis from "ioredis";
+import { make } from "../../src/input/redis";
+import { resolveAfter } from "../../src/utils";
+import { consume } from "../test-utils";
+
+const redisUrl = "redis://localhost:6379/0";
+
+const testEvents = [
+  { n: "foo", d: "fooo" },
+  { n: "bar", d: "barr" },
+  { n: "baz", d: "bazz" },
+];
+
+test("@redis The redis input form builds a one-way channel", async () => {
+  // Arrange
+  const [channel, stopped] = make("irrelevant", "irrelevant", {
+    instance: { path: redisUrl },
+    subscribe: ["ignored"],
+  });
+  // Act
+  const sent = channel.send();
+  await Promise.race([channel.close(), stopped]);
+  // Assert
+  expect(sent).toEqual(false);
+});
+
+test("@redis The redis input form works for single instance, subscribe", async () => {
+  // Arrange
+  const client = new Redis(redisUrl);
+  await client.flushall();
+  const [channel, stopped] = make("irrelevant", "irrelevant", {
+    instance: redisUrl,
+    subscribe: ["test1-ignored", "test1", "test1-also-ignored"],
+  });
+  // Act
+  await resolveAfter(1000); // Give time for the subscription to establish
+  for (const event of testEvents) {
+    await client.publish("test1", JSON.stringify(event));
+  }
+  await client.quit();
+  const [output] = await Promise.all([
+    consume(channel.receive),
+    Promise.race([resolveAfter(1000).then(() => channel.close()), stopped]),
+  ]);
+  // Assert
+  expect(output.map((e) => e.toJSON()).map(({ n, d }) => ({ n, d }))).toEqual(
+    testEvents
+  );
+});
+
+test("@redis The redis input form works for single instance, psubscribe", async () => {
+  // Arrange
+  const client = new Redis(redisUrl);
+  await client.flushall();
+  const [channel, stopped] = make("irrelevant", "irrelevant", {
+    instance: redisUrl,
+    psubscribe: ["test2*"],
+  });
+  // Act
+  await resolveAfter(1000); // Give time for the subscription to establish
+  for (const event of testEvents) {
+    await client.publish("test2loremipsum", JSON.stringify(event));
+  }
+  await client.quit();
+  const [output] = await Promise.all([
+    consume(channel.receive),
+    Promise.race([resolveAfter(1000).then(() => channel.close()), stopped]),
+  ]);
+  // Assert
+  expect(output.map((e) => e.toJSON()).map(({ n, d }) => ({ n, d }))).toEqual(
+    testEvents
+  );
+});
+
+test("@redis The redis input form works for single instance, blpop", async () => {
+  // Arrange
+  const client = new Redis(redisUrl);
+  await client.flushall();
+  const [channel, stopped] = make("irrelevant", "irrelevant", {
+    instance: redisUrl,
+    blpop: ["test3", "test3-ignored"],
+  });
+  // Act
+  await client.rpush(
+    "test3",
+    ...testEvents.map((event) => JSON.stringify(event))
+  );
+  await client.quit();
+  const [output] = await Promise.all([
+    consume(channel.receive),
+    Promise.race([resolveAfter(1000).then(() => channel.close()), stopped]),
+  ]);
+  // Assert
+  expect(output.map((e) => e.toJSON()).map(({ n, d }) => ({ n, d }))).toEqual(
+    testEvents
+  );
+});
+
+test("@redis The redis input form works for single instance, brpop", async () => {
+  // Arrange
+  const client = new Redis(redisUrl);
+  await client.flushall();
+  const [channel, stopped] = make("irrelevant", "irrelevant", {
+    instance: redisUrl,
+    brpop: ["test4", "test4-ignored"],
+  });
+  // Act
+  await client.lpush(
+    "test4",
+    ...testEvents.map((event) => JSON.stringify(event))
+  );
+  await client.quit();
+  const [output] = await Promise.all([
+    consume(channel.receive),
+    Promise.race([resolveAfter(1000).then(() => channel.close()), stopped]),
+  ]);
+  // Assert
+  expect(output.map((e) => e.toJSON()).map(({ n, d }) => ({ n, d }))).toEqual(
+    testEvents
+  );
+});

--- a/__tests__/input/stdin.ts
+++ b/__tests__/input/stdin.ts
@@ -15,7 +15,7 @@ afterEach(() => mockSTDINGetter.mockClear());
 import { make } from "../../src/input/stdin";
 import { consume } from "../test-utils";
 
-test("The stdin input form works as expected", async () => {
+test("@standalone The stdin input form works as expected", async () => {
   // Arrange
   const [channel] = make("irrelevant", "irrelevant", {
     wrap: { name: "test", raw: true },

--- a/__tests__/input/tail.ts
+++ b/__tests__/input/tail.ts
@@ -18,7 +18,7 @@ afterEach(() => {
   fs.rmdirSync(path.dirname(tmpFilePath));
 });
 
-test("The tail input form works as expected", async () => {
+test("@standalone The tail input form works as expected", async () => {
   // Arrange
   const [channel] = make("irrelevant", "irrelevant", {
     path: tmpFilePath,

--- a/__tests__/io/http-client.ts
+++ b/__tests__/io/http-client.ts
@@ -22,7 +22,7 @@ class TestError extends Error {
   }
 }
 
-test("Request retrying works for all attempts", async () => {
+test("@standalone Request retrying works for all attempts", async () => {
   // Arrange
   mockRequest.mockImplementation(() =>
     Promise.reject(new TestError("test error", { status: 503 }))
@@ -32,7 +32,7 @@ test("Request retrying works for all attempts", async () => {
   expect(mockRequest).toHaveBeenCalledTimes(HTTP_CLIENT_MAX_RETRIES + 1);
 });
 
-test("Request retrying only works on 5xx status codes", async () => {
+test("@standalone Request retrying only works on 5xx status codes", async () => {
   // Arrange
   mockRequest.mockImplementation(() =>
     Promise.reject(new TestError("test error", { status: 400 }))
@@ -42,7 +42,7 @@ test("Request retrying only works on 5xx status codes", async () => {
   expect(mockRequest).toHaveBeenCalledTimes(1);
 });
 
-test("Request retrying can rescueue a request", async () => {
+test("@standalone Request retrying can rescueue a request", async () => {
   // Arrange
   mockRequest
     .mockImplementationOnce(() =>

--- a/__tests__/io/jq.ts
+++ b/__tests__/io/jq.ts
@@ -6,7 +6,7 @@ afterEach(() => {
   closeInstances();
 });
 
-test("Integration with jq works as expected", async () => {
+test("@standalone Integration with jq works as expected", async () => {
   // Arrange
   const { send, receive } = await makeChannel(`{key: join(" ")}`);
   // Act
@@ -18,7 +18,7 @@ test("Integration with jq works as expected", async () => {
   expect(second).toEqual({ key: "lorem ipsum" });
 });
 
-test("Failures during processing interrupt parsing of the current payload", async () => {
+test("@standalone Failures during processing interrupt parsing of the current payload", async () => {
   // Arrange
   const { send, receive } = await makeChannel(`.[] | (1 / .)`);
   // Act
@@ -34,7 +34,7 @@ test("Failures during processing interrupt parsing of the current payload", asyn
   expect(third).toEqual(4);
 });
 
-test("Closing a jq channel ends the stream", async () => {
+test("@standalone Closing a jq channel ends the stream", async () => {
   // Arrange
   const { send, receive, close } = await makeChannel(".");
   // Act

--- a/__tests__/io/read-stream.ts
+++ b/__tests__/io/read-stream.ts
@@ -6,7 +6,7 @@ import { parseLines, parseJson } from "../../src/io/read-stream";
 // PARSE_BUFFER_SIZE is 32 when the test environment is
 // active. Changing that value explicitly will break them.
 
-test("Parsing lines is kindof equivalent to splitting on linebreaks", async () => {
+test("@standalone Parsing lines is kindof equivalent to splitting on linebreaks", async () => {
   const stream = Readable.from([
     "lorem\nipsum\r\ndo", // Any combination of linebreaks can be used.
     "lor\rsit\n", // Even a single carriage return.
@@ -21,17 +21,17 @@ test("Parsing lines is kindof equivalent to splitting on linebreaks", async () =
   ]);
 });
 
-test("An empty stream can be parsed", async () => {
+test("@standalone An empty stream can be parsed", async () => {
   const stream = Readable.from([]);
   expect(await consume(parseJson(stream))).toEqual([]);
 });
 
-test("A singleton stream can be parsed", async () => {
+test("@standalone A singleton stream can be parsed", async () => {
   const stream = Readable.from(["{}"]);
   expect(await consume(parseJson(stream))).toEqual([{}]);
 });
 
-test("A non-singleton stream can be parsed", async () => {
+test("@standalone A non-singleton stream can be parsed", async () => {
   const stream = Readable.from([
     ' {"hello": "world"}\n{"goodbye":',
     '"world"}',
@@ -42,7 +42,7 @@ test("A non-singleton stream can be parsed", async () => {
   ]);
 });
 
-test("A windows-style line-break is harmless", async () => {
+test("@standalone A windows-style line-break is harmless", async () => {
   const stream = Readable.from([
     ' {"hello": "world"}\r\n{"goodbye":',
     '"world"}',
@@ -53,7 +53,7 @@ test("A windows-style line-break is harmless", async () => {
   ]);
 });
 
-test("A trailing line break is harmless", async () => {
+test("@standalone A trailing line break is harmless", async () => {
   const stream = Readable.from([
     '{"hello": "world"}\n{"goodbye":',
     '"world"}\n',
@@ -64,7 +64,7 @@ test("A trailing line break is harmless", async () => {
   ]);
 });
 
-test("Objects exceeding the parse buffer size limit are dropped", async () => {
+test("@standalone Objects exceeding the parse buffer size limit are dropped", async () => {
   const stream = Readable.from([
     '{"hello": "world"}\n{"goodbye":',
     '"world", "this": "will be dropped because it exceeds 32 bytes',
@@ -76,7 +76,7 @@ test("Objects exceeding the parse buffer size limit are dropped", async () => {
   ]);
 });
 
-test("Lines containing invalid JSON are dropped", async () => {
+test("@standalone Lines containing invalid JSON are dropped", async () => {
   const stream = Readable.from([
     '{"hello": "world"}\nfoobarbaz',
     "lorem\n{",
@@ -88,7 +88,7 @@ test("Lines containing invalid JSON are dropped", async () => {
   ]);
 });
 
-test("Limited streams don't read past their limit", async () => {
+test("@standalone Limited streams don't read past their limit", async () => {
   const data = [
     '{"hello": "world"}\n{"goodbye":',
     '"world"}\n{"just": "kidding"}',

--- a/__tests__/log.ts
+++ b/__tests__/log.ts
@@ -13,7 +13,7 @@ afterEach(() => {
   mockedConsoleError.mockRestore();
 });
 
-test("Loggers can be created according to the current log level", () => {
+test("@standalone Loggers can be created according to the current log level", () => {
   // Assumes the current log level is 'error'.
   // This tests uses the fact that the null logger functions return
   // null, while the active logger functions return undefined.

--- a/__tests__/pattern.ts
+++ b/__tests__/pattern.ts
@@ -1,56 +1,56 @@
 import * as pattern from "../src/pattern";
 
-test("Event names can be checked for validity", () => {
+test("@standalone Event names can be checked for validity", () => {
   expect(pattern.isValidEventName("foo.bar.baz")).toBe(true);
   expect(pattern.isValidEventName(".bar.baz")).toBe(false);
   expect(pattern.isValidEventName("*.bar.baz")).toBe(false);
 });
 
-test("Fixed pattern matches an equal string", () => {
+test("@standalone Fixed pattern matches an equal string", () => {
   expect(pattern.match("foo.bar.baz", "foo.bar.baz")).toBe(true);
 });
 
-test("Fixed pattern rejects not-equal string", () => {
+test("@standalone Fixed pattern rejects not-equal string", () => {
   expect(pattern.match("foo.bar.bars", "foo.bar.baz")).toBe(false);
 });
 
-test("Fixed pattern rejects substring", () => {
+test("@standalone Fixed pattern rejects substring", () => {
   expect(pattern.match("foo.bar", "foo.bar.baz")).toBe(false);
 });
 
-test("Star-wildcard pattern matches correctly", () => {
+test("@standalone Star-wildcard pattern matches correctly", () => {
   expect(pattern.match("foo.bar.baz", "foo.*.baz")).toBe(true);
 });
 
-test("Hash-wildcard pattern matches zero occurrences", () => {
+test("@standalone Hash-wildcard pattern matches zero occurrences", () => {
   expect(pattern.match("foo.bar.baz", "#.foo.bar.baz")).toBe(true);
   expect(pattern.match("foo", "foo.#")).toBe(true);
 });
 
-test("Hash-wildcard pattern matches many occurrences", () => {
+test("@standalone Hash-wildcard pattern matches many occurrences", () => {
   expect(pattern.match("foo.bar.baz", "#.baz")).toBe(true);
 });
 
-test("String patterns can be checked for validity", () => {
+test("@standalone String patterns can be checked for validity", () => {
   expect(pattern.isValidPattern("foo.#.*")).toBe(true);
 });
 
-test("The empty string is NOT a valid pattern", () => {
+test("@standalone The empty string is NOT a valid pattern", () => {
   expect(pattern.isValidPattern("")).toBe(false);
 });
 
-test("Invalid string patterns are detected", () => {
+test("@standalone Invalid string patterns are detected", () => {
   expect(pattern.isValidPattern("foo*.bar")).toBe(false);
 });
 
-test("Composite patterns can be checked for validity", () => {
+test("@standalone Composite patterns can be checked for validity", () => {
   expect(pattern.isValidPattern({ or: ["foo.bar", "foo.baz"] })).toBe(true);
   expect(pattern.isValidPattern({ and: ["foo.bar", "foo.baz"] })).toBe(true);
   expect(pattern.isValidPattern({ not: "foo.bar" })).toBe(true);
   expect(pattern.isValidPattern({ xor: ["foo.bar", "foo.baz"] })).toBe(false);
 });
 
-test("Complex composite patterns work properly", () => {
+test("@standalone Complex composite patterns work properly", () => {
   expect(
     pattern.match("foo.bar.baz", { not: { or: ["foo.bar", "foo.baz"] } })
   ).toBe(true);

--- a/__tests__/pipeline.ts
+++ b/__tests__/pipeline.ts
@@ -8,7 +8,7 @@ const dummyStepFactory = async () =>
 
 // Tests start here.
 
-test("Pipeline validation detects usage of the reserved step name", () => {
+test("@standalone Pipeline validation detects usage of the reserved step name", () => {
   // Arrange
   const pipeline = {
     name: "Test",
@@ -29,7 +29,7 @@ test("Pipeline validation detects usage of the reserved step name", () => {
   expect(() => validate(pipeline)).toThrow("reserved name");
 });
 
-test("Pipeline validation detects duplicate step names", () => {
+test("@standalone Pipeline validation detects duplicate step names", () => {
   // Arrange
   const pipeline = {
     name: "Test",
@@ -55,7 +55,7 @@ test("Pipeline validation detects duplicate step names", () => {
   expect(() => validate(pipeline)).toThrow("not unique");
 });
 
-test("Pipeline validation detects dangling dependencies", () => {
+test("@standalone Pipeline validation detects dangling dependencies", () => {
   // Arrange
   const pipeline = {
     name: "Test",
@@ -76,7 +76,7 @@ test("Pipeline validation detects dangling dependencies", () => {
   expect(() => validate(pipeline)).toThrow("dangling dependency");
 });
 
-test("Pipeline validation accepts a direct dependency to the input alias", () => {
+test("@standalone Pipeline validation accepts a direct dependency to the input alias", () => {
   // Arrange
   const pipeline = {
     name: "Test",
@@ -97,7 +97,7 @@ test("Pipeline validation accepts a direct dependency to the input alias", () =>
   expect(() => validate(pipeline)).not.toThrow();
 });
 
-test("Pipeline validation detects a trivial graph cycle", () => {
+test("@standalone Pipeline validation detects a trivial graph cycle", () => {
   // Arrange
   const pipeline = {
     name: "Test",
@@ -113,7 +113,7 @@ test("Pipeline validation detects a trivial graph cycle", () => {
   expect(() => validate(pipeline)).toThrow("dependency cycle");
 });
 
-test("Pipeline validation detects a graph cycle of greater length", () => {
+test("@standalone Pipeline validation detects a graph cycle of greater length", () => {
   // Arrange
   const pipeline = {
     name: "Test",
@@ -141,7 +141,7 @@ test("Pipeline validation detects a graph cycle of greater length", () => {
   );
 });
 
-test("Pipeline validation accepts shared dependencies", () => {
+test("@standalone Pipeline validation accepts shared dependencies", () => {
   // Arrange
   const pipeline = {
     name: "Test",

--- a/__tests__/step-functions/deduplicate.ts
+++ b/__tests__/step-functions/deduplicate.ts
@@ -2,7 +2,7 @@ import { make as makeEvent } from "../../src/event";
 import { make } from "../../src/step-functions/deduplicate";
 import { consume } from "../test-utils";
 
-test("Deduplicate works as expected", async () => {
+test("@standalone Deduplicate works as expected", async () => {
   // Arrange
   const channel = await make("irrelevant", "irrelevant", null);
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
@@ -26,7 +26,7 @@ test("Deduplicate works as expected", async () => {
   expect(output.map((e) => e.data)).toEqual([3.14, 3.141, 3.1415]);
 });
 
-test("Deduplicate can consider specific parts of events", async () => {
+test("@standalone Deduplicate can consider specific parts of events", async () => {
   // Arrange
   const channel = await make("irrelevant", "irrelevant", {
     "consider-name": false,

--- a/__tests__/step-functions/expose-http.ts
+++ b/__tests__/step-functions/expose-http.ts
@@ -4,7 +4,7 @@ import { make } from "../../src/step-functions/expose-http";
 import { resolveAfter } from "../../src/utils";
 import { consume } from "../test-utils";
 
-test("Expose-http works as expected", async () => {
+test("@standalone Expose-http works as expected", async () => {
   // Arrange
   const channel = await make("irrelevant", "irrelevant", {
     endpoint: "/events",
@@ -68,7 +68,7 @@ test("Expose-http works as expected", async () => {
   );
 });
 
-test("Expose-http can transform responses using a jq filter", async () => {
+test("@standalone Expose-http can transform responses using a jq filter", async () => {
   // Arrange
   const channel = await make("irrelevant", "irrelevant", {
     endpoint: "/events",

--- a/__tests__/step-functions/keep-when.ts
+++ b/__tests__/step-functions/keep-when.ts
@@ -2,7 +2,7 @@ import { make as makeEvent } from "../../src/event";
 import { make } from "../../src/step-functions/keep-when";
 import { consume } from "../test-utils";
 
-test("Keep-when works as expected", async () => {
+test("@standalone Keep-when works as expected", async () => {
   // Arrange
   const channel = await make("irrelevant", "irrelevant", { type: "object" });
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];

--- a/__tests__/step-functions/keep.ts
+++ b/__tests__/step-functions/keep.ts
@@ -2,7 +2,7 @@ import { make as makeEvent } from "../../src/event";
 import { make } from "../../src/step-functions/keep";
 import { consume } from "../test-utils";
 
-test("Keep works as expected", async () => {
+test("@standalone Keep works as expected", async () => {
   // Arrange
   const channel = await make("irrelevant", "irrelevant", 3);
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
@@ -26,7 +26,7 @@ test("Keep works as expected", async () => {
   expect(output.map((e) => e.data)).toEqual([1, 2, 3]);
 });
 
-test("Keep doesn't fail if the incoming event vector has fewer events", async () => {
+test("@standalone Keep doesn't fail if the incoming event vector has fewer events", async () => {
   // Arrange
   const channel = await make("irrelevant", "irrelevant", "3");
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];

--- a/__tests__/step-functions/rename.ts
+++ b/__tests__/step-functions/rename.ts
@@ -2,7 +2,7 @@ import { make as makeEvent } from "../../src/event";
 import { make } from "../../src/step-functions/rename";
 import { consume } from "../test-utils";
 
-test("Renaming with replacement works as expected", async () => {
+test("@standalone Renaming with replacement works as expected", async () => {
   // Arrange
   const channel = await make("irrelevant", "irrelevant", {
     replace: "replaced",
@@ -29,7 +29,7 @@ test("Renaming with replacement works as expected", async () => {
   ]);
 });
 
-test("Renaming with prepend works as expected", async () => {
+test("@standalone Renaming with prepend works as expected", async () => {
   // Arrange
   const channel = await make("irrelevant", "irrelevant", {
     prepend: "prefix.",
@@ -56,7 +56,7 @@ test("Renaming with prepend works as expected", async () => {
   ]);
 });
 
-test("Renaming with append works as expected", async () => {
+test("@standalone Renaming with append works as expected", async () => {
   // Arrange
   const channel = await make("irrelevant", "irrelevant", {
     append: ".suffix",
@@ -83,7 +83,7 @@ test("Renaming with append works as expected", async () => {
   ]);
 });
 
-test("Renaming with prepend and append works as expected", async () => {
+test("@standalone Renaming with prepend and append works as expected", async () => {
   // Arrange
   const channel = await make("irrelevant", "irrelevant", {
     prepend: "prefix.",

--- a/__tests__/step-functions/send-file.ts
+++ b/__tests__/step-functions/send-file.ts
@@ -29,7 +29,7 @@ afterEach((done) => {
 
 const readFile = (path: string): string => readFileSync(path, "utf-8");
 
-test("Send-file works as expected", async () => {
+test("@standalone Send-file works as expected", async () => {
   expect(fixtures.directory).not.toBeNull();
   const path = join(fixtures.directory as string, "test");
   // Arrange
@@ -52,7 +52,7 @@ test("Send-file works as expected", async () => {
   );
 });
 
-test("Send-stdout works when using a jq program to preprocess the data", async () => {
+test("@standalone Send-file works when using a jq program to preprocess the data", async () => {
   expect(fixtures.directory).not.toBeNull();
   const path = join(fixtures.directory as string, "test");
   // Arrange
@@ -77,7 +77,7 @@ test("Send-stdout works when using a jq program to preprocess the data", async (
   expect(readFile(path)).toEqual('hello\n["world"]\n');
 });
 
-test("Send-file doesn't overwrite file contents", async () => {
+test("@standalone Send-file doesn't overwrite file contents", async () => {
   expect(fixtures.directory).not.toBeNull();
   const path = join(fixtures.directory as string, "test");
   writeFileSync(path, "this was here before those 'events' arrived");

--- a/__tests__/step-functions/send-http.ts
+++ b/__tests__/step-functions/send-http.ts
@@ -16,7 +16,7 @@ import { make } from "../../src/step-functions/send-http";
 import { resolveAfter } from "../../src/utils";
 import { consume } from "../test-utils";
 
-test("Send-http works as expected", async () => {
+test("@standalone Send-http works as expected", async () => {
   // Arrange
   const target = "http://nothing";
   const method = "PATCH";
@@ -44,7 +44,7 @@ test("Send-http works as expected", async () => {
   });
 });
 
-test("Send-http works when specifying a target plainly", async () => {
+test("@standalone Send-http works when specifying a target plainly", async () => {
   // Arrange
   const target = "http://nothing";
   const method = "POST";
@@ -72,7 +72,7 @@ test("Send-http works when specifying a target plainly", async () => {
   });
 });
 
-test("Send-http works when specifying a jq expression and headers", async () => {
+test("@standalone Send-http works when specifying a jq expression and headers", async () => {
   // Arrange
   const target = "http://nothing";
   const method = "PUT";

--- a/__tests__/step-functions/send-receive-http.ts
+++ b/__tests__/step-functions/send-receive-http.ts
@@ -19,7 +19,7 @@ import { make } from "../../src/step-functions/send-receive-http";
 import { resolveAfter } from "../../src/utils";
 import { consume } from "../test-utils";
 
-test("Send-receive-http works as expected", async () => {
+test("@standalone Send-receive-http works as expected", async () => {
   // Arrange
   const target = "http://nothing";
   const method = "POST";
@@ -48,7 +48,7 @@ test("Send-receive-http works as expected", async () => {
   });
 });
 
-test("Send-receive-http works when using jq as intermediary", async () => {
+test("@standalone Send-receive-http works when using jq as intermediary", async () => {
   // Arrange
   const target = "http://nothing";
   const method = "PATCH";

--- a/__tests__/step-functions/send-receive-jq.ts
+++ b/__tests__/step-functions/send-receive-jq.ts
@@ -3,7 +3,7 @@ import { resolveAfter } from "../../src/utils";
 import { make } from "../../src/step-functions/send-receive-jq";
 import { consume } from "../test-utils";
 
-test("Send-receive-jq works as expected", async () => {
+test("@standalone Send-receive-jq works as expected", async () => {
   // Arrange
   const pipelineName = "test";
   const pipelineSignature = "signature";
@@ -25,7 +25,7 @@ test("Send-receive-jq works as expected", async () => {
   expect(output.map((e) => e.data)).toEqual(["replaced!", "replaced!"]);
 });
 
-test("Send-receive-jq will filter out events that are invalid", async () => {
+test("@standalone Send-receive-jq will filter out events that are invalid", async () => {
   // Arrange
   const pipelineName = "test";
   const pipelineSignature = "signature";

--- a/__tests__/step-functions/send-redis.ts
+++ b/__tests__/step-functions/send-redis.ts
@@ -1,0 +1,126 @@
+import Redis from "ioredis";
+import { make as makeEvent } from "../../src/event";
+import { make } from "../../src/step-functions/send-redis";
+import { resolveAfter } from "../../src/utils";
+import { consume } from "../test-utils";
+
+const redisUrl = "redis://localhost:6379/0";
+
+test("@redis Send-redis works for single instance, publish", async () => {
+  // Arrange
+  const client = new Redis(redisUrl);
+  await client.flushall();
+  const channel = await make("irrelevant", "irrelevant", {
+    instance: redisUrl,
+    publish: "send-test1",
+  });
+  const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
+  const events = [
+    await makeEvent("a", "hello", trace),
+    await makeEvent("a", "world", trace),
+  ];
+  const receivedEvents: string[] = [];
+  client.on("message", (_, received: string) => receivedEvents.push(received));
+  await client.subscribe("send-test1");
+  // Act
+  channel.send(events);
+  const [output] = await Promise.all([
+    consume(channel.receive),
+    channel.close(),
+  ]);
+  await client.quit();
+  // Assert
+  expect(output.map((e) => e.data)).toEqual(["hello", "world"]);
+  expect(receivedEvents).toEqual(events.map((e) => JSON.stringify(e)));
+});
+
+test("@redis Send-redis works for single instance, rpush", async () => {
+  // Arrange
+  const client = new Redis(redisUrl);
+  await client.flushall();
+  const channel = await make("irrelevant", "irrelevant", {
+    instance: redisUrl,
+    rpush: "send-test2",
+  });
+  const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
+  const events = [
+    await makeEvent("a", "hello", trace),
+    await makeEvent("a", "world", trace),
+  ];
+  // Act
+  channel.send(events);
+  const [output, blpopResults] = await Promise.all([
+    consume(channel.receive),
+    (async () => {
+      const r1 = await client.blpop("send-test2", 0);
+      const r2 = await client.blpop("send-test2", 0);
+      return [r1?.[1], r2?.[1]];
+    })(),
+    channel.close(),
+  ]);
+  await client.quit();
+  // Assert
+  expect(output.map((e) => e.data)).toEqual(["hello", "world"]);
+  expect(blpopResults).toEqual(events.map((e) => JSON.stringify(e)));
+});
+
+test("@redis Send-redis works for single instance, lpush", async () => {
+  // Arrange
+  const client = new Redis(redisUrl);
+  await client.flushall();
+  const channel = await make("irrelevant", "irrelevant", {
+    instance: redisUrl,
+    lpush: "send-test3",
+  });
+  const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
+  const events = [
+    await makeEvent("a", "hello", trace),
+    await makeEvent("a", "world", trace),
+  ];
+  // Act
+  channel.send(events);
+  const [output, brpopResults] = await Promise.all([
+    consume(channel.receive),
+    (async () => {
+      const r1 = await client.brpop("send-test3", 0);
+      const r2 = await client.brpop("send-test3", 0);
+      return [r1?.[1], r2?.[1]];
+    })(),
+    channel.close(),
+  ]);
+  await client.quit();
+  // Assert
+  expect(output.map((e) => e.data)).toEqual(["hello", "world"]);
+  expect(brpopResults).toEqual(events.map((e) => JSON.stringify(e)));
+});
+
+test("@redis Send-redis works in tandem with jq", async () => {
+  // Arrange
+  const client = new Redis(redisUrl);
+  await client.flushall();
+  const channel = await make("irrelevant", "irrelevant", {
+    instance: redisUrl,
+    lpush: "send-test4",
+    "jq-expr": ".[].d",
+  });
+  const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
+  const events = [
+    await makeEvent("a", "hello", trace),
+    await makeEvent("a", "world", trace),
+  ];
+  // Act
+  channel.send(events);
+  const [output, brpopResults] = await Promise.all([
+    consume(channel.receive),
+    (async () => {
+      const r1 = await client.brpop("send-test4", 0);
+      const r2 = await client.brpop("send-test4", 0);
+      return [r1?.[1], r2?.[1]];
+    })(),
+    resolveAfter(1000).then(() => channel.close()),
+  ]);
+  await client.quit();
+  // Assert
+  expect(output.map((e) => e.data)).toEqual(["hello", "world"]);
+  expect(brpopResults).toEqual(['"hello"', '"world"']);
+});

--- a/__tests__/step-functions/send-stdout.ts
+++ b/__tests__/step-functions/send-stdout.ts
@@ -16,7 +16,7 @@ afterEach(() => {
   mockedConsoleLog.mockRestore();
 });
 
-test("Send-stdout works as expected", async () => {
+test("@standalone Send-stdout works as expected", async () => {
   // Arrange
   const channel = await make("irrelevant", "irrelevant", null);
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
@@ -38,7 +38,7 @@ test("Send-stdout works as expected", async () => {
   ]);
 });
 
-test("Send-stdout works when using a jq program to preprocess the data", async () => {
+test("@standalone Send-stdout works when using a jq program to preprocess the data", async () => {
   // Arrange
   const channel = await make("irrelevant", "irrelevant", {
     "jq-expr": ".[].d",

--- a/__tests__/step.ts
+++ b/__tests__/step.ts
@@ -3,7 +3,7 @@ import { make as makeEvent } from "../src/event";
 import { makeWindowingChannel } from "../src/step";
 import { resolveAfter } from "../src/utils";
 
-test("A size-1 windowed channel doesn't care about timeouts", async () => {
+test("@standalone A size-1 windowed channel doesn't care about timeouts", async () => {
   // Arrange
   const channel = makeWindowingChannel({
     name: "test",
@@ -27,7 +27,7 @@ test("A size-1 windowed channel doesn't care about timeouts", async () => {
   expect(values.map((x) => x.map((y) => y.data))).toEqual([[1], [2], [3], [4]]);
 });
 
-test("A windowed channel truncates the last group after being closed", async () => {
+test("@standalone A windowed channel truncates the last group after being closed", async () => {
   // Arrange
   const channel = makeWindowingChannel({
     name: "test",
@@ -58,7 +58,7 @@ test("A windowed channel truncates the last group after being closed", async () 
   ]);
 });
 
-test("A windowed channel using reduce mode creates disjoint groups", async () => {
+test("@standalone A windowed channel using reduce mode creates disjoint groups", async () => {
   // Arrange
   const channel = makeWindowingChannel({
     name: "test",
@@ -85,7 +85,7 @@ test("A windowed channel using reduce mode creates disjoint groups", async () =>
   ]);
 });
 
-test("A windowed channel uses its timeout to produce partial groups", async () => {
+test("@standalone A windowed channel uses its timeout to produce partial groups", async () => {
   // Arrange
   const channel = makeWindowingChannel({
     name: "test",

--- a/__tests__/test-utils.ts
+++ b/__tests__/test-utils.ts
@@ -26,6 +26,6 @@ export const consume = async <T>(
 };
 
 // Provide an empty test to appease jest.
-test("Nothing", () => {
+test("@standalone Nothing", () => {
   // Empty test.
 });

--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -13,7 +13,7 @@ afterEach(() => {
   mockedConsoleError.mockRestore();
 });
 
-test("Signatures can be obtained for any JSON-encodable thing", async () => {
+test("@standalone Signatures can be obtained for any JSON-encodable thing", async () => {
   const signature = await utils.getSignature(
     "foo",
     2,
@@ -25,11 +25,11 @@ test("Signatures can be obtained for any JSON-encodable thing", async () => {
   expect(signature).toBeTruthy();
 });
 
-test("Signatures can't be generated for non JSON-encodable things", async () => {
+test("@standalone Signatures can't be generated for non JSON-encodable things", async () => {
   await expect(utils.getSignature(undefined)).rejects.toThrow();
 });
 
-test("Signatures are distinct", async () => {
+test("@standalone Signatures are distinct", async () => {
   const s1 = await utils.getSignature("foo", "bar");
   const s2 = await utils.getSignature("foobar");
   const s3 = await utils.getSignature("foo", undefined, "bar");
@@ -38,7 +38,7 @@ test("Signatures are distinct", async () => {
   expect(s2).not.toEqual(s3);
 });
 
-test("Environment variables can be replaced in objects", () => {
+test("@standalone Environment variables can be replaced in objects", () => {
   const obj = {
     foo: "bar ${NODE_ENV}",
     baz: ["stuff", { "${NODE_ENV} key": "Look at this!" }],

--- a/examples/composition/README.md
+++ b/examples/composition/README.md
@@ -19,8 +19,8 @@ curl --data-binary "@test-events.ndjson" "http://localhost:8000/events"
 ```
 
 Logs of interest will be visible on the first terminal, and they will
-refer to four instances of CDP: `first`, `second`, `third` and
-`fourth` (the name of the respective services in
+refer to four instances of CDP: `first`, `second`, `third`, `fourth`
+and `fifth` (the name of the respective services in
 `docker-compose.yml`).
 
 To clean up, cancel the process in the first terminal with Ctrl-C and
@@ -33,10 +33,11 @@ docker compose down -v
 ## What does it do?
 
 The example shows four pipelines that take input from an [HTTP
-input](/../../#http), [`tail` input](/../../#tail) and [`poll`
-input](/../../#poll) and execute some forwarding steps with the
-[`send-http`](/../../#send-http), [`send-file`](/../../#send-file) and
-[`expose-http`](/../../#expose-http) functions. Also, events are
+input](/../../#http), [`tail` input](/../../#tail), [`poll`
+input](/../../#poll) and [`redis` input](/../../#redis) and execute
+some forwarding steps with the [`send-http`](/../../#send-http),
+[`send-file`](/../../#send-file), [`expose-http`](/../../#expose-http)
+and [`send-redis`](/../../#send-redis) functions. Also, events are
 logged in each step showing the pipelines they've been in.
 
 Worth noting is that the `second` and `fourth` services (and pipeline
@@ -59,4 +60,7 @@ The pipeline files are named after the docker compose services:
   receives events from the `second` one via HTTP and forwards them to
   the `fourth` one via HTTP exposition.
 - [`pipeline-fourth.yaml`](pipeline-fourth.yaml) is the pipeline that
-  fetches events from the `third` pipeline via HTTP polling.
+  fetches events from the `third` pipeline via HTTP polling and
+  forwards them to the `fifth` one via the redis PUBLISH command.
+- [`pipeline-fifth.yaml`](pipeline-fifth.yaml) is the pipeline that
+  receives events from a redis PSUBSCRIBE subscription.

--- a/examples/composition/docker-compose.yml
+++ b/examples/composition/docker-compose.yml
@@ -38,6 +38,16 @@ services:
       SOURCE: http://third:8002/events
     depends_on:
       - third
+      - fifth
+
+  fifth:
+    <<: *cdp
+    command: ["/app/pipeline-fifth.yaml"]
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7-alpine
 
 volumes:
   bridge:

--- a/examples/composition/pipeline-fifth.yaml
+++ b/examples/composition/pipeline-fifth.yaml
@@ -1,7 +1,9 @@
 ---
-name: "fourth"
+name: "fifth"
 input:
-  poll: "${SOURCE}"
+  redis:
+    instance: redis://redis:6379/0
+    psubscribe: "*-fifth"
 
 steps:
   debug:
@@ -15,11 +17,3 @@ steps:
             (.[].t | map(.p) | join(" --> ")),
             ")"
           ] | join("")
-
-  forward:
-    after:
-      - debug
-    flatmap:
-      send-redis:
-        instance: redis://redis:6379/0
-        publish: fourth-fifth

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.5",
       "license": "ISC",
       "dependencies": {
+        "@redis/client": "^1.1.0",
         "agentkeepalive": "^4.2.1",
         "ajv": "^8.11.0",
         "axios": "^0.26.1",
@@ -1051,6 +1052,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@redis/client": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.1.0.tgz",
+      "integrity": "sha512-xO9JDIgzsZYDl3EvFhl6LC52DP3q3GCMUer8zHgKV6qSYsq1zB+pZs9+T80VgcRogrlRYhi4ZlfX6A+bHiBAgA==",
+      "dependencies": {
+        "cluster-key-slot": "1.1.0",
+        "generic-pool": "3.8.2",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -2007,6 +2021,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {
@@ -3308,6 +3330,14 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
+    },
+    "node_modules/generic-pool": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.8.2.tgz",
+      "integrity": "sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg==",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -6054,8 +6084,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -6899,6 +6928,16 @@
         "fastq": "^1.6.0"
       }
     },
+    "@redis/client": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.1.0.tgz",
+      "integrity": "sha512-xO9JDIgzsZYDl3EvFhl6LC52DP3q3GCMUer8zHgKV6qSYsq1zB+pZs9+T80VgcRogrlRYhi4ZlfX6A+bHiBAgA==",
+      "requires": {
+        "cluster-key-slot": "1.1.0",
+        "generic-pool": "3.8.2",
+        "yallist": "4.0.0"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -7640,6 +7679,11 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
     },
     "co": {
       "version": "4.6.0",
@@ -8522,6 +8566,11 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
+    },
+    "generic-pool": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.8.2.tgz",
+      "integrity": "sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -10562,8 +10611,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.4.5",
       "license": "ISC",
       "dependencies": {
-        "@redis/client": "^1.1.0",
         "agentkeepalive": "^4.2.1",
         "ajv": "^8.11.0",
         "axios": "^0.26.1",
         "commander": "^9.2.0",
+        "ioredis": "^5.0.6",
         "koa": "^2.13.4",
         "prom-client": "^14.0.1",
         "tail-file": "^1.4.15",
@@ -674,6 +674,11 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.1.1.tgz",
+      "integrity": "sha512-fsR4P/ROllzf/7lXYyElUJCheWdTJVJvOTps8v9IWKFATxR61ANOlnoPqhH099xYLrJGpc2ZQ28B3rMeUt5VQg=="
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1050,19 +1055,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@redis/client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.1.0.tgz",
-      "integrity": "sha512-xO9JDIgzsZYDl3EvFhl6LC52DP3q3GCMUer8zHgKV6qSYsq1zB+pZs9+T80VgcRogrlRYhi4ZlfX6A+bHiBAgA==",
-      "dependencies": {
-        "cluster-key-slot": "1.1.0",
-        "generic-pool": "3.8.2",
-        "yallist": "4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -2271,6 +2263,14 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
     },
+    "node_modules/denque": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -3331,14 +3331,6 @@
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
     },
-    "node_modules/generic-pool": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.8.2.tgz",
-      "integrity": "sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg==",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3665,6 +3657,29 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ioredis": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.0.6.tgz",
+      "integrity": "sha512-KUm7wPzIet9QrFMoMm09/4bkfVKBUD9KXwBitP3hrNkZ+A6NBndweXGwYIB/7szHcTZgfo7Kvx88SxljJV4D9A==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.0.1",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -4693,6 +4708,16 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5207,6 +5232,25 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -5471,6 +5515,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/statuses": {
       "version": "1.5.0",
@@ -6084,7 +6133,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -6627,6 +6677,11 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@ioredis/commands": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.1.1.tgz",
+      "integrity": "sha512-fsR4P/ROllzf/7lXYyElUJCheWdTJVJvOTps8v9IWKFATxR61ANOlnoPqhH099xYLrJGpc2ZQ28B3rMeUt5VQg=="
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -6926,16 +6981,6 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
-      }
-    },
-    "@redis/client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.1.0.tgz",
-      "integrity": "sha512-xO9JDIgzsZYDl3EvFhl6LC52DP3q3GCMUer8zHgKV6qSYsq1zB+pZs9+T80VgcRogrlRYhi4ZlfX6A+bHiBAgA==",
-      "requires": {
-        "cluster-key-slot": "1.1.0",
-        "generic-pool": "3.8.2",
-        "yallist": "4.0.0"
       }
     },
     "@sinonjs/commons": {
@@ -7869,6 +7914,11 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
     },
+    "denque": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -8567,11 +8617,6 @@
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
     },
-    "generic-pool": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.8.2.tgz",
-      "integrity": "sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg=="
-    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -8802,6 +8847,22 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ioredis": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.0.6.tgz",
+      "integrity": "sha512-KUm7wPzIet9QrFMoMm09/4bkfVKBUD9KXwBitP3hrNkZ+A6NBndweXGwYIB/7szHcTZgfo7Kvx88SxljJV4D9A==",
+      "requires": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.0.1",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -9602,6 +9663,16 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -9983,6 +10054,19 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -10170,6 +10254,11 @@
           "dev": true
         }
       }
+    },
+    "standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "statuses": {
       "version": "1.5.0",
@@ -10611,7 +10700,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
+    "@redis/client": "^1.1.0",
     "agentkeepalive": "^4.2.1",
     "ajv": "^8.11.0",
     "axios": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "description": "Composable Data Pipelines",
   "main": "src/index.ts",
   "scripts": {
-    "test": "jest --coverage",
-    "check": "jest -i && eslint . --ext .ts && tsc",
+    "start-redis": "docker start cdp-redis || docker run --rm -p 6379:6379 --name cdp-redis -d redis:7-alpine",
+    "pretest": "npm run start-redis",
+    "test": "jest -i --coverage",
+    "posttest": "docker stop cdp-redis",
+    "check": "jest -i -t @standalone && eslint . --ext .ts && tsc",
     "build": "esbuild src/index.ts --bundle --minify --platform=node --target=node16 --outdir=build",
     "check-and-build": "npm run check && npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@redis/client": "^1.1.0",
     "agentkeepalive": "^4.2.1",
     "ajv": "^8.11.0",
     "axios": "^0.26.1",
     "commander": "^9.2.0",
+    "ioredis": "^5.0.6",
     "koa": "^2.13.4",
     "prom-client": "^14.0.1",
     "tail-file": "^1.4.15",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,17 +1,7 @@
 import { match, P } from "ts-pattern";
 import { flatMap, compose } from "./async-queue";
 import { INPUT_DRAIN_TIMEOUT, HEALTH_CHECK_INTERVAL } from "./conf";
-import {
-  Event,
-  WrapDirective,
-  wrapDirectiveSchema,
-  validateWrap,
-} from "./event";
-import { make as makeGeneratorInput } from "./input/generator";
-import { make as makeSTDINInput } from "./input/stdin";
-import { make as makeTailInput } from "./input/tail";
-import { make as makeHTTPInput } from "./input/http";
-import { make as makePollInput } from "./input/poll";
+import { Event, validateWrap } from "./event";
 import { isHealthy } from "./io/jq";
 import { makeLogger } from "./log";
 import {
@@ -28,17 +18,84 @@ import {
 } from "./pattern";
 import { StepDefinition, Pipeline, validate, run } from "./pipeline";
 import { makeWindowed } from "./step";
-import { make as makeDeduplicateFunction } from "./step-functions/deduplicate";
-import { make as makeKeepFunction } from "./step-functions/keep";
-import { make as makeKeepWhenFunction } from "./step-functions/keep-when";
-import { make as makeRenameFunction } from "./step-functions/rename";
-import { make as makeExposeHTTPFunction } from "./step-functions/expose-http";
-import { make as makeSendHTTPFunction } from "./step-functions/send-http";
-import { make as makeSendReceiveHTTPFunction } from "./step-functions/send-receive-http";
-import { make as makeSendReceiveJqFunction } from "./step-functions/send-receive-jq";
-import { make as makeSendFileFunction } from "./step-functions/send-file";
-import { make as makeSendSTDOUTFunction } from "./step-functions/send-stdout";
 import { ajv, compileThrowing, getSignature, resolveAfter } from "./utils";
+// Input forms
+import {
+  GeneratorInputOptions,
+  optionsSchema as generatorInputOptionsSchema,
+  make as makeGeneratorInput,
+} from "./input/generator";
+import {
+  STDINInputOptions,
+  optionsSchema as stdinInputOptionsSchema,
+  make as makeSTDINInput,
+} from "./input/stdin";
+import {
+  TailInputOptions,
+  optionsSchema as tailInputOptionsSchema,
+  make as makeTailInput,
+} from "./input/tail";
+import {
+  HTTPInputOptions,
+  optionsSchema as httpInputOptionsSchema,
+  make as makeHTTPInput,
+} from "./input/http";
+import {
+  PollInputOptions,
+  optionsSchema as pollInputOptionsSchema,
+  make as makePollInput,
+} from "./input/poll";
+// Step functions
+import {
+  DeduplicateFunctionOptions,
+  optionsSchema as deduplicateFunctionOptionsSchema,
+  make as makeDeduplicateFunction,
+} from "./step-functions/deduplicate";
+import {
+  KeepFunctionOptions,
+  optionsSchema as keepFunctionOptionsSchema,
+  make as makeKeepFunction,
+} from "./step-functions/keep";
+import {
+  KeepWhenFunctionOptions,
+  optionsSchema as keepWhenFunctionOptionsSchema,
+  make as makeKeepWhenFunction,
+} from "./step-functions/keep-when";
+import {
+  RenameFunctionOptions,
+  optionsSchema as renameFunctionOptionsSchema,
+  make as makeRenameFunction,
+} from "./step-functions/rename";
+import {
+  ExposeHTTPFunctionOptions,
+  optionsSchema as exposeHTTPFunctionOptionsSchema,
+  make as makeExposeHTTPFunction,
+} from "./step-functions/expose-http";
+import {
+  SendHTTPFunctionOptions,
+  optionsSchema as sendHTTPFunctionOptionsSchema,
+  make as makeSendHTTPFunction,
+} from "./step-functions/send-http";
+import {
+  SendReceiveHTTPFunctionOptions,
+  optionsSchema as sendReceiveHTTPFunctionOptionsSchema,
+  make as makeSendReceiveHTTPFunction,
+} from "./step-functions/send-receive-http";
+import {
+  SendReceiveJqFunctionOptions,
+  optionsSchema as sendReceiveJqFunctionOptionsSchema,
+  make as makeSendReceiveJqFunction,
+} from "./step-functions/send-receive-jq";
+import {
+  SendFileFunctionOptions,
+  optionsSchema as sendFileFunctionOptionsSchema,
+  make as makeSendFileFunction,
+} from "./step-functions/send-file";
+import {
+  SendSTDOUTFunctionOptions,
+  optionsSchema as sendSTDOUTFunctionOptionsSchema,
+  make as makeSendSTDOUTFunction,
+} from "./step-functions/send-stdout";
 
 /**
  * A logger instance namespaced to this module.
@@ -46,603 +103,68 @@ import { ajv, compileThrowing, getSignature, resolveAfter } from "./utils";
 const logger = makeLogger("api");
 
 /**
- * The `generator` input produces events at a regular rate.
+ * Build an ajv schema for an object with a single key and a subschema
+ * for the value.
+ *
+ * @param key The single key found in the expected objects.
+ * @param schema The schema for the value mapped to the key.
+ * @returns A schema for the wrapped objects.
  */
-interface GeneratorInputTemplate {
-  generator: { name?: string; seconds?: number | string } | string | null;
-}
-const generatorInputTemplateSchema = {
+const makeWrapperSchema = (key: string, schema: object) => ({
   type: "object",
-  properties: {
-    generator: {
-      anyOf: [
-        {
-          type: "object",
-          properties: {
-            name: { type: "string", minLength: 1 },
-            seconds: {
-              anyOf: [
-                { type: "number", exclusiveMinimum: 0 },
-                { type: "string", pattern: "^[0-9]+\\.?[0-9]*$" },
-              ],
-            },
-          },
-          additionalProperties: false,
-          required: [],
-        },
-        { type: "string", minLength: 1 },
-        { type: "null" },
-      ],
-    },
-  },
+  properties: { [key]: schema },
   additionalProperties: false,
-  required: ["generator"],
-};
-
-/**
- * The `stdin` input form ingests events from STDIN.
- */
-interface STDINInputTemplate {
-  stdin: { wrap?: WrapDirective } | null;
-}
-const stdinInputTemplateSchema = {
-  type: "object",
-  properties: {
-    stdin: {
-      anyOf: [
-        {
-          type: "object",
-          properties: { wrap: wrapDirectiveSchema },
-          additionalProperties: false,
-          required: [],
-        },
-        { type: "null" },
-      ],
-    },
-  },
-  additionalProperties: false,
-  required: ["stdin"],
-};
-
-/**
- * The `tail` input form ingests events from a file.
- */
-interface TailInputTemplate {
-  tail:
-    | string
-    | { path: string; ["start-at"]?: "start" | "end"; wrap?: WrapDirective };
-}
-const tailInputTemplateSchema = {
-  type: "object",
-  properties: {
-    tail: {
-      anyOf: [
-        { type: "string", minLength: 1 },
-        {
-          type: "object",
-          properties: {
-            path: { type: "string", minLength: 1 },
-            "start-at": { enum: ["start", "end"] },
-            wrap: wrapDirectiveSchema,
-          },
-          additionalProperties: false,
-          required: ["path"],
-        },
-      ],
-    },
-  },
-  additionalProperties: false,
-  required: ["tail"],
-};
-
-/**
- * The `http` input form ingests events at an HTTP endpoint.
- */
-interface HTTPInputTemplate {
-  http:
-    | string
-    | {
-        endpoint: string;
-        port?: number | string;
-        wrap?: WrapDirective;
-      };
-}
-const httpInputTemplateSchema = {
-  type: "object",
-  properties: {
-    http: {
-      anyOf: [
-        { type: "string", minLength: 1, pattern: "^/.*$" },
-        {
-          type: "object",
-          properties: {
-            endpoint: { type: "string", minLength: 1, pattern: "^/.*$" },
-            port: {
-              anyOf: [
-                { type: "integer", minimum: 1, maximum: 65535 },
-                { type: "string", pattern: "^[0-9]*[1-9][0-9]*$" },
-              ],
-            },
-            wrap: wrapDirectiveSchema,
-          },
-          additionalProperties: false,
-          required: ["endpoint"],
-        },
-      ],
-    },
-  },
-  additionalProperties: false,
-  required: ["http"],
-};
-
-/**
- * The `poll` input form pulls events by executing HTTP GET requests.
- */
-interface PollInputTemplate {
-  poll:
-    | string
-    | {
-        target: string;
-        seconds?: number | string;
-        headers?: { [key: string]: string | number | boolean };
-        wrap?: WrapDirective;
-      };
-}
-const pollInputTemplateSchema = {
-  type: "object",
-  properties: {
-    poll: {
-      anyOf: [
-        { type: "string", minLength: 1 },
-        {
-          type: "object",
-          properties: {
-            target: { type: "string", minLength: 1 },
-            seconds: {
-              anyOf: [
-                { type: "number", exclusiveMinimum: 0 },
-                { type: "string", pattern: "^[0-9]+\\.?[0-9]*$" },
-              ],
-            },
-            headers: {
-              type: "object",
-              properties: {},
-              additionalProperties: {
-                anyOf: [
-                  { type: "string" },
-                  { type: "number" },
-                  { type: "boolean" },
-                ],
-              },
-            },
-            wrap: wrapDirectiveSchema,
-          },
-          additionalProperties: false,
-          required: ["target"],
-        },
-      ],
-    },
-  },
-  additionalProperties: false,
-  required: ["poll"],
-};
+  required: [key],
+});
 
 /**
  * An input template is one of the provided ones.
  **/
 type InputTemplate =
-  | GeneratorInputTemplate
-  | STDINInputTemplate
-  | TailInputTemplate
-  | HTTPInputTemplate
-  | PollInputTemplate;
+  | { generator: GeneratorInputOptions }
+  | { stdin: STDINInputOptions }
+  | { tail: TailInputOptions }
+  | { http: HTTPInputOptions }
+  | { poll: PollInputOptions };
 const inputTemplateSchema = {
   anyOf: [
-    generatorInputTemplateSchema,
-    stdinInputTemplateSchema,
-    tailInputTemplateSchema,
-    httpInputTemplateSchema,
-    pollInputTemplateSchema,
+    makeWrapperSchema("generator", generatorInputOptionsSchema),
+    makeWrapperSchema("stdin", stdinInputOptionsSchema),
+    makeWrapperSchema("tail", tailInputOptionsSchema),
+    makeWrapperSchema("http", httpInputOptionsSchema),
+    makeWrapperSchema("poll", pollInputOptionsSchema),
   ],
-};
-
-/**
- * A `rename` function changes the name of the events it receives.
- */
-interface RenameFunctionTemplate {
-  rename:
-    | {
-        append?: string;
-        prepend?: string;
-      }
-    | { replace: string };
-}
-const renameFunctionTemplateSchema = {
-  type: "object",
-  properties: {
-    rename: {
-      anyOf: [
-        {
-          type: "object",
-          properties: {
-            append: { type: "string", minLength: 1 },
-            prepend: { type: "string", minLength: 1 },
-          },
-          additionalProperties: false,
-          required: [],
-        },
-        {
-          type: "object",
-          properties: {
-            replace: { type: "string", minLength: 1 },
-          },
-          additionalProperties: false,
-          required: ["replace"],
-        },
-      ],
-    },
-  },
-  additionalProperties: false,
-  required: ["rename"],
-};
-
-/**
- * A `deduplicate` function removes event duplicates from the batches
- * it receives, considering various pieces of the events.
- */
-interface DeduplicateFunctionTemplate {
-  deduplicate: {
-    ["consider-name"]?: boolean;
-    ["consider-data"]?: boolean;
-    ["consider-trace"]?: boolean;
-  } | null;
-}
-const deduplicateFunctionTemplateSchema = {
-  type: "object",
-  properties: {
-    deduplicate: {
-      anyOf: [
-        {
-          type: "object",
-          properties: {
-            "consider-name": { type: "boolean" },
-            "consider-data": { type: "boolean" },
-            "consider-trace": { type: "boolean" },
-          },
-          additionalProperties: false,
-          required: [],
-        },
-        { type: "null" },
-      ],
-    },
-  },
-  additionalProperties: false,
-  required: ["deduplicate"],
-};
-
-/**
- * A `keep` function limits event batches to a specific size, after
- * windowing.
- */
-interface KeepFunctionTemplate {
-  keep: number | string;
-}
-const keepFunctionTemplateSchema = {
-  type: "object",
-  properties: {
-    keep: {
-      anyOf: [
-        { type: "integer", minimum: 1 },
-        { type: "string", pattern: "^[0-9]*[1-9][0-9]*$" },
-      ],
-    },
-  },
-  additionalProperties: false,
-  required: ["keep"],
-};
-
-/**
- * A `keep-when` function removes events that don't comply with a
- * specific jsonschema.
- */
-interface KeepWhenFunctionTemplate {
-  ["keep-when"]: object;
-}
-const keepWhenFunctionTemplateSchema = {
-  type: "object",
-  properties: {
-    "keep-when": { type: "object" },
-  },
-  additionalProperties: false,
-  required: ["keep-when"],
-};
-
-/**
- * A `send-stdout` function emits events as serialized JSON to STDOUT,
- * and forwards the received events as-is to the rest of the pipeline.
- */
-interface SendSTDOUTFunctionTemplate {
-  ["send-stdout"]: {
-    ["jq-expr"]?: string;
-  } | null;
-}
-const sendSTDOUTFunctionTemplateSchema = {
-  type: "object",
-  properties: {
-    "send-stdout": {
-      anyOf: [
-        {
-          type: "object",
-          properties: {
-            "jq-expr": { type: "string", minLength: 1 },
-          },
-          additionalProperties: false,
-          required: [],
-        },
-        { type: "null" },
-      ],
-    },
-  },
-  additionalProperties: false,
-  required: ["send-stdout"],
-};
-
-/**
- * A `send-file` function appends events as serialized JSON to the
- * specified file, and forwards the received events as-is to the rest
- * of the pipeline.
- */
-interface SendFileFunctionTemplate {
-  ["send-file"]:
-    | string
-    | {
-        path: string;
-        ["jq-expr"]?: string;
-      };
-}
-const sendFileFunctionTemplateSchema = {
-  type: "object",
-  properties: {
-    "send-file": {
-      anyOf: [
-        { type: "string", minLength: 1 },
-        {
-          type: "object",
-          properties: {
-            path: { type: "string", minLength: 1 },
-            "jq-expr": { type: "string", minLength: 1 },
-          },
-          additionalProperties: false,
-          required: ["path"],
-        },
-      ],
-    },
-  },
-  additionalProperties: false,
-  required: ["send-file"],
-};
-
-/**
- * A `send-http` function emits event batches to a remote HTTP
- * endpoint, ignores the response entirely and forwards the original
- * events to the rest of the pipeline.
- */
-interface SendHTTPFunctionTemplate {
-  ["send-http"]:
-    | string
-    | {
-        target: string;
-        method?: "POST" | "PUT" | "PATCH";
-        ["jq-expr"]?: string;
-        headers?: { [key: string]: string | number | boolean };
-        concurrent?: number | string;
-      };
-}
-const sendHTTPFunctionTemplateSchema = {
-  type: "object",
-  properties: {
-    "send-http": {
-      anyOf: [
-        { type: "string", minLength: 1 },
-        {
-          type: "object",
-          properties: {
-            target: { type: "string", minLength: 1 },
-            method: { enum: ["POST", "PUT", "PATCH"] },
-            "jq-expr": { type: "string", minLength: 1 },
-            headers: {
-              type: "object",
-              properties: {},
-              additionalProperties: {
-                anyOf: [
-                  { type: "string" },
-                  { type: "number" },
-                  { type: "boolean" },
-                ],
-              },
-            },
-            concurrent: {
-              anyOf: [
-                { type: "integer", minimum: 1 },
-                { type: "string", pattern: "^[0-9]*[1-9][0-9]*$" },
-              ],
-            },
-          },
-          additionalProperties: false,
-          required: ["target"],
-        },
-      ],
-    },
-  },
-  additionalProperties: false,
-  required: ["send-http"],
-};
-
-/**
- * An `expose-http` function keeps a buffer of windows that it exposes
- * in an HTTP server.
- */
-interface ExposeHTTPFunctionTemplate {
-  ["expose-http"]: {
-    endpoint: string;
-    port: number | string;
-    responses: number | string;
-    headers?: { [key: string]: string | string[] };
-    ["jq-expr"]?: string;
-  };
-}
-const exposeHTTPFunctionTemplateSchema = {
-  type: "object",
-  properties: {
-    "expose-http": {
-      type: "object",
-      properties: {
-        endpoint: { type: "string", minLength: 1, pattern: "^/.*$" },
-        port: {
-          anyOf: [
-            { type: "integer", minimum: 1, maximum: 65535 },
-            { type: "string", pattern: "^[0-9]*[1-9][0-9]*$" },
-          ],
-        },
-        responses: {
-          anyOf: [
-            { type: "integer", minimum: 1 },
-            { type: "string", pattern: "^[0-9]*[1-9][0-9]*$" },
-          ],
-        },
-        headers: {
-          type: "object",
-          properties: {},
-          additionalProperties: {
-            anyOf: [
-              { type: "string" },
-              { type: "array", items: { type: "string" } },
-            ],
-          },
-        },
-        "jq-expr": { type: "string", minLength: 1 },
-      },
-      additionalProperties: false,
-      required: ["endpoint", "port", "responses"],
-    },
-  },
-  additionalProperties: false,
-  required: ["expose-http"],
-};
-
-/**
- * A `send-receive-jq` function processes batches of events with a jq
- * program, and the transformed events are sent back to the rest of
- * the pipeline.
- */
-interface SendReceiveJqFunctionTemplate {
-  ["send-receive-jq"]:
-    | string
-    | {
-        ["jq-expr"]: string;
-        wrap?: WrapDirective;
-      };
-}
-const sendReceiveJqFunctionTemplateSchema = {
-  type: "object",
-  properties: {
-    "send-receive-jq": {
-      anyOf: [
-        { type: "string", minLength: 1 },
-        {
-          type: "object",
-          properties: {
-            "jq-expr": { type: "string", minLength: 1 },
-            wrap: wrapDirectiveSchema,
-          },
-          additionalProperties: false,
-          required: ["jq-expr"],
-        },
-      ],
-    },
-  },
-  additionalProperties: false,
-  required: ["send-receive-jq"],
-};
-
-/**
- * A `send-receive-http` function processes batches of events with a
- * remote HTTP service. The service is expected to respond with the
- * transformed events, which get forwarded to the rest of the
- * pipeline.
- */
-interface SendReceiveHTTPFunctionTemplate {
-  ["send-receive-http"]:
-    | string
-    | {
-        target: string;
-        method?: "POST" | "PUT" | "PATCH";
-        ["jq-expr"]?: string;
-        headers?: { [key: string]: string | number | boolean };
-        wrap?: WrapDirective;
-      };
-}
-const sendReceiveHTTPFunctionTemplateSchema = {
-  type: "object",
-  properties: {
-    "send-receive-http": {
-      anyOf: [
-        { type: "string", minLength: 1 },
-        {
-          type: "object",
-          properties: {
-            target: { type: "string", minLength: 1 },
-            method: { enum: ["POST", "PUT", "PATCH"] },
-            "jq-expr": { type: "string", minLength: 1 },
-            headers: {
-              type: "object",
-              properties: {},
-              additionalProperties: {
-                anyOf: [
-                  { type: "string" },
-                  { type: "number" },
-                  { type: "boolean" },
-                ],
-              },
-            },
-            wrap: wrapDirectiveSchema,
-          },
-          additionalProperties: false,
-          required: ["target"],
-        },
-      ],
-    },
-  },
-  additionalProperties: false,
-  required: ["send-receive-http"],
 };
 
 /**
  * A step function template is one of the provided ones.
  **/
 type StepFunctionTemplate =
-  | RenameFunctionTemplate
-  | DeduplicateFunctionTemplate
-  | KeepFunctionTemplate
-  | KeepWhenFunctionTemplate
-  | SendSTDOUTFunctionTemplate
-  | SendFileFunctionTemplate
-  | SendHTTPFunctionTemplate
-  | ExposeHTTPFunctionTemplate
-  | SendReceiveJqFunctionTemplate
-  | SendReceiveHTTPFunctionTemplate;
+  | { rename: RenameFunctionOptions }
+  | { deduplicate: DeduplicateFunctionOptions }
+  | { keep: KeepFunctionOptions }
+  | { "keep-when": KeepWhenFunctionOptions }
+  | { "send-stdout": SendSTDOUTFunctionOptions }
+  | { "send-file": SendFileFunctionOptions }
+  | { "send-http": SendHTTPFunctionOptions }
+  | { "expose-http": ExposeHTTPFunctionOptions }
+  | { "send-receive-jq": SendReceiveJqFunctionOptions }
+  | { "send-receive-http": SendReceiveHTTPFunctionOptions };
 const stepFunctionTemplateSchema = {
   anyOf: [
-    renameFunctionTemplateSchema,
-    deduplicateFunctionTemplateSchema,
-    keepFunctionTemplateSchema,
-    keepWhenFunctionTemplateSchema,
-    sendSTDOUTFunctionTemplateSchema,
-    sendFileFunctionTemplateSchema,
-    sendHTTPFunctionTemplateSchema,
-    exposeHTTPFunctionTemplateSchema,
-    sendReceiveJqFunctionTemplateSchema,
-    sendReceiveHTTPFunctionTemplateSchema,
+    makeWrapperSchema("rename", renameFunctionOptionsSchema),
+    makeWrapperSchema("deduplicate", deduplicateFunctionOptionsSchema),
+    makeWrapperSchema("keep", keepFunctionOptionsSchema),
+    makeWrapperSchema("keep-when", keepWhenFunctionOptionsSchema),
+    makeWrapperSchema("send-stdout", sendSTDOUTFunctionOptionsSchema),
+    makeWrapperSchema("send-file", sendFileFunctionOptionsSchema),
+    makeWrapperSchema("send-http", sendHTTPFunctionOptionsSchema),
+    makeWrapperSchema("expose-http", exposeHTTPFunctionOptionsSchema),
+    makeWrapperSchema("send-receive-jq", sendReceiveJqFunctionOptionsSchema),
+    makeWrapperSchema(
+      "send-receive-http",
+      sendReceiveHTTPFunctionOptionsSchema
+    ),
   ],
 };
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -77,6 +77,11 @@ import {
   make as makeExposeHTTPFunction,
 } from "./step-functions/expose-http";
 import {
+  SendRedisFunctionOptions,
+  optionsSchema as sendRedisFunctionOptionsSchema,
+  make as makeSendRedisFunction,
+} from "./step-functions/send-redis";
+import {
   SendHTTPFunctionOptions,
   optionsSchema as sendHTTPFunctionOptionsSchema,
   make as makeSendHTTPFunction,
@@ -154,6 +159,7 @@ type StepFunctionTemplate =
   | { "send-stdout": SendSTDOUTFunctionOptions }
   | { "send-file": SendFileFunctionOptions }
   | { "send-http": SendHTTPFunctionOptions }
+  | { "send-redis": SendRedisFunctionOptions }
   | { "expose-http": ExposeHTTPFunctionOptions }
   | { "send-receive-jq": SendReceiveJqFunctionOptions }
   | { "send-receive-http": SendReceiveHTTPFunctionOptions };
@@ -166,6 +172,7 @@ const stepFunctionTemplateSchema = {
     makeWrapperSchema("send-stdout", sendSTDOUTFunctionOptionsSchema),
     makeWrapperSchema("send-file", sendFileFunctionOptionsSchema),
     makeWrapperSchema("send-http", sendHTTPFunctionOptionsSchema),
+    makeWrapperSchema("send-redis", sendRedisFunctionOptionsSchema),
     makeWrapperSchema("expose-http", exposeHTTPFunctionOptionsSchema),
     makeWrapperSchema("send-receive-jq", sendReceiveJqFunctionOptionsSchema),
     makeWrapperSchema(
@@ -502,6 +509,9 @@ export const runPipeline = async (
       )
       .with({ "expose-http": P.select() }, (f) =>
         makeExposeHTTPFunction(...ctx, f)
+      )
+      .with({ "send-redis": P.select() }, (f) =>
+        makeSendRedisFunction(...ctx, f)
       )
       .with({ "send-http": P.select() }, (f) => makeSendHTTPFunction(...ctx, f))
       .with({ "send-file": P.select() }, (f) => makeSendFileFunction(...ctx, f))

--- a/src/async-queue.ts
+++ b/src/async-queue.ts
@@ -69,6 +69,11 @@ export class Queue<Type> {
  */
 export class AsyncQueue<Type> {
   /**
+   * A name useful for debugging.
+   */
+  name: string;
+
+  /**
    * The data in the queue.
    */
   data: Queue<Type> = new Queue();
@@ -107,7 +112,8 @@ export class AsyncQueue<Type> {
    */
   iterator: () => AsyncGenerator<Type>;
 
-  constructor() {
+  constructor(name = "anonymous queue") {
+    this.name = name;
     this.lock = new Promise((resolve) => {
       this.releaseLock = resolve;
     });
@@ -131,7 +137,7 @@ export class AsyncQueue<Type> {
    */
   push(value: Type): boolean {
     if (this.closed) {
-      logger.warn("push() attempted on a closed queue");
+      logger.warn(`push() attempted on a closed queue: ${this.name}`);
       return false;
     }
     this.data.push(value);
@@ -160,7 +166,9 @@ export class AsyncQueue<Type> {
   async shift(): Promise<Type> {
     await this.lock;
     if (this.data.length === 0) {
-      throw new Error("shift() attempted on an empty closed queue");
+      throw new Error(
+        `shift() attempted on an empty closed queue: ${this.name}`
+      );
     }
     const value = this.data.shift() as Type;
     if (this.data.length === 0 && !this.closed) {
@@ -193,7 +201,7 @@ export class AsyncQueue<Type> {
    * Return a string representation of this queue.
    */
   toString(): string {
-    return `AsyncQueue<closed=${this.closed}, items=${this.data.length}>`;
+    return `AsyncQueue<name=${this.name}, closed=${this.closed}, items=${this.data.length}>`;
   }
 }
 

--- a/src/input/generator.ts
+++ b/src/input/generator.ts
@@ -72,7 +72,7 @@ export const make = (
       ? parseFloat(options.seconds)
       : options.seconds ?? 1;
   const intervalDuration = durationSeconds * 1000;
-  const queue = new AsyncQueue<number>();
+  const queue = new AsyncQueue<number>("input.generator");
   const interval = setInterval(
     () => queue.push(Math.random()),
     intervalDuration

--- a/src/input/generator.ts
+++ b/src/input/generator.ts
@@ -8,6 +8,38 @@ import { makeLogger } from "../log";
 const logger = makeLogger("input/generator");
 
 /**
+ * Options for this input form.
+ */
+export type GeneratorInputOptions =
+  | { name?: string; seconds?: number | string }
+  | string
+  | null;
+
+/**
+ * An ajv schema for the options.
+ */
+export const optionsSchema = {
+  anyOf: [
+    {
+      type: "object",
+      properties: {
+        name: { type: "string", minLength: 1 },
+        seconds: {
+          anyOf: [
+            { type: "number", exclusiveMinimum: 0 },
+            { type: "string", pattern: "^[0-9]+\\.?[0-9]*$" },
+          ],
+        },
+      },
+      additionalProperties: false,
+      required: [],
+    },
+    { type: "string", minLength: 1 },
+    { type: "null" },
+  ],
+};
+
+/**
  * Creates an input channel that produces events at a fixed rate. It
  * is mainly intended to help with testing pipelines.
  *
@@ -22,7 +54,7 @@ const logger = makeLogger("input/generator");
 export const make = (
   pipelineName: string,
   pipelineSignature: string,
-  options: { name?: string; seconds?: number | string } | string | null
+  options: GeneratorInputOptions
 ): [Channel<never, Event>, Promise<void>] => {
   const eventParser = makeNewEventParser(pipelineName, pipelineSignature);
   const n =

--- a/src/input/http.ts
+++ b/src/input/http.ts
@@ -6,6 +6,7 @@ import {
   makeNewEventParser,
   parseChannel,
   WrapDirective,
+  wrapDirectiveSchema,
   chooseParser,
   makeWrapper,
 } from "../event";
@@ -17,6 +18,37 @@ import { makeLogger } from "../log";
  * A logger instance namespaced to this module.
  */
 const logger = makeLogger("input/http");
+
+/**
+ * Options for this input form.
+ */
+export type HTTPInputOptions =
+  | string
+  | { endpoint: string; port?: number | string; wrap?: WrapDirective };
+
+/**
+ * An ajv schema for the options.
+ */
+export const optionsSchema = {
+  anyOf: [
+    { type: "string", minLength: 1, pattern: "^/.*$" },
+    {
+      type: "object",
+      properties: {
+        endpoint: { type: "string", minLength: 1, pattern: "^/.*$" },
+        port: {
+          anyOf: [
+            { type: "integer", minimum: 1, maximum: 65535 },
+            { type: "string", pattern: "^[0-9]*[1-9][0-9]*$" },
+          ],
+        },
+        wrap: wrapDirectiveSchema,
+      },
+      additionalProperties: false,
+      required: ["endpoint"],
+    },
+  ],
+};
 
 /**
  * Creates an input channel based on data coming from HTTP. Returns a
@@ -34,9 +66,7 @@ const logger = makeLogger("input/http");
 export const make = (
   pipelineName: string,
   pipelineSignature: string,
-  options:
-    | string
-    | { endpoint: string; port?: number | string; wrap?: WrapDirective }
+  options: HTTPInputOptions
 ): [Channel<never, Event>, Promise<void>] => {
   const parse = chooseParser(
     (typeof options === "string" ? {} : options)?.wrap

--- a/src/input/http.ts
+++ b/src/input/http.ts
@@ -81,7 +81,7 @@ export const make = (
       : options.port ?? HTTP_SERVER_DEFAULT_PORT;
   const port = typeof rawPort === "string" ? parseInt(rawPort) : rawPort;
   const eventParser = makeNewEventParser(pipelineName, pipelineSignature);
-  const queue = new AsyncQueue<unknown>();
+  const queue = new AsyncQueue<unknown>("input.http");
   const server = makeHTTPServer(port, async (ctx) => {
     logger.debug("Received request:", ctx.request.method, ctx.request.path);
     if (ctx.request.method === "POST" && ctx.request.path === endpoint) {

--- a/src/input/poll.ts
+++ b/src/input/poll.ts
@@ -93,7 +93,7 @@ export const make = (
   const target = typeof options === "string" ? options : options.target;
   const headers = typeof options === "string" ? {} : options.headers ?? {};
   const eventParser = makeNewEventParser(pipelineName, pipelineSignature);
-  const queue = new AsyncQueue<unknown>();
+  const queue = new AsyncQueue<unknown>("input.poll");
   // Keep a record of the latest ETag, so as to not duplicate events.
   let latestETag: string | null = null;
   // One poll is a GET request to the target.

--- a/src/input/redis.ts
+++ b/src/input/redis.ts
@@ -1,0 +1,263 @@
+import { Readable } from "stream";
+import RedisClient from "ioredis";
+import { Redis, Cluster } from "ioredis";
+import { Channel, AsyncQueue, flatMap } from "../async-queue";
+import {
+  Event,
+  arrivalTimestamp,
+  makeNewEventParser,
+  parseChannel,
+  WrapDirective,
+  wrapDirectiveSchema,
+  chooseParser,
+  makeWrapper,
+} from "../event";
+import { makeLogger } from "../log";
+
+/**
+ * A logger instance namespaced to this module.
+ */
+const logger = makeLogger("input/redis");
+
+/**
+ * Options for this input form.
+ */
+export type RedisInputOptions = {
+  url: string | string[];
+  "address-map"?: Record<string, string>;
+  subscribe?: string | string[];
+  psubscribe?: string | string[];
+  blpop?: string | string[];
+  brpop?: string | string[];
+  wrap?: WrapDirective;
+};
+
+/**
+ * Build a possible schema variation, to be combined with all other
+ * variations in an `anyOf`.
+ *
+ * @param key The variating key.
+ * @returns A partial schema.
+ */
+const buildSchema = (key: string): object => ({
+  type: "object",
+  properties: {
+    url: {
+      anyOf: [
+        { type: "string", minLength: 1 },
+        { type: "array", items: { type: "string", minLength: 1 }, minItems: 1 },
+      ],
+    },
+    "address-map": {
+      type: "object",
+      properties: {},
+      additionalProperties: { type: "string", minLength: 1 },
+      required: [],
+    },
+    [key]: {
+      anyOf: [
+        { type: "string", minLength: 1 },
+        { type: "array", items: { type: "string", minLength: 1 }, minItems: 1 },
+      ],
+    },
+    wrap: wrapDirectiveSchema,
+  },
+  additionalProperties: false,
+  required: ["url", key],
+});
+
+/**
+ * An ajv schema for the options.
+ */
+export const optionsSchema = {
+  anyOf: [
+    buildSchema("subscribe"),
+    buildSchema("psubscribe"),
+    buildSchema("blpop"),
+    buildSchema("brpop"),
+  ],
+};
+
+/**
+ * Default port to assume for redis connections.
+ */
+const DEFAULT_PORT = 6379;
+
+/**
+ * Timeout in seconds for BLPOP and BRPOP operations.
+ */
+const POP_TIMEOUT = 5;
+
+/**
+ * Normalize a variant argument. Useful for redis commands. Always
+ * returns an array of strings.
+ *
+ * @param option The argument to normalize into an array of strings.
+ * @returns A normalize version of the given argument.
+ */
+const toargs = (option: string[] | string | undefined): string[] =>
+  typeof option === "undefined"
+    ? []
+    : Array.isArray(option)
+    ? option
+    : [option];
+
+/**
+ * Creates an input channel based on data coming from a redis
+ * instance. Returns a pair of [channel, endPromise].
+ *
+ * @param pipelineName The name of the pipeline that will use this
+ * input.
+ * @param pipelineSignature The signature of the pipeline that will
+ * use this input.
+ * @param options The redis options to configure the input channel.
+ * @returns A pair of a channel that connects to a redis instance or
+ * cluster and produces events from SUBSCRIBE, PSUBSCRIBE, BLPOP or
+ * BRPOP, and a promise indicating the channel got closed from
+ * external causes.
+ */
+export const make = (
+  pipelineName: string,
+  pipelineSignature: string,
+  options: RedisInputOptions
+): [Channel<never, Event>, Promise<void>] => {
+  const parse = chooseParser(options.wrap);
+  const wrapper = makeWrapper(options.wrap);
+  const eventParser = makeNewEventParser(pipelineName, pipelineSignature);
+  let client: Redis | Cluster;
+  if (
+    Array.isArray(options.url) ||
+    typeof options["address-map"] !== "undefined"
+  ) {
+    client = new Cluster(
+      Array.isArray(options.url) ? options.url : [options.url],
+      typeof options["address-map"] === "undefined"
+        ? {}
+        : {
+            natMap: Object.fromEntries(
+              Object.entries(options["address-map"]).map(([key, address]) => {
+                // address is given as a string, and the library
+                // expects a (host, port) pair
+                const pair = address.split(":");
+                if (pair.length === 1) {
+                  return [key, { host: address, port: DEFAULT_PORT }];
+                }
+                const rawPort = pair[pair.length - 1];
+                return [
+                  key,
+                  {
+                    host: pair.slice(0, -1).join(":"),
+                    port: parseInt(rawPort, 10),
+                  },
+                ];
+              })
+            ),
+          }
+    );
+  } else {
+    client = new RedisClient(options.url);
+  }
+  client.on("error", (err: Error) => logger.warn(`redis client error: ${err}`));
+
+  const channel = flatMap(async (message: Buffer) => {
+    arrivalTimestamp.update();
+    const things = [];
+    for await (const thing of parse(Readable.from([message]), message.length)) {
+      things.push(wrapper(thing));
+    }
+    return things;
+  }, new AsyncQueue<Buffer>().asChannel());
+
+  // The same thing in three flavours: a stopping flag, a callback,
+  // and a promise.
+  let isDone = false;
+  let notifyDone: () => void;
+  const done = (
+    new Promise((resolve) => {
+      notifyDone = resolve;
+    }) as Promise<void>
+  ).then(() => {
+    isDone = true;
+  });
+
+  // Initialize endless redis consumption
+  const consuming = (async () => {
+    if (typeof options.subscribe !== "undefined") {
+      await client.subscribe(...toargs(options.subscribe));
+      client.on("messageBuffer", (_, message: Buffer) => channel.send(message));
+      await done;
+    } else if (typeof options.psubscribe !== "undefined") {
+      await client.psubscribe(...toargs(options.psubscribe));
+      client.on("pmessageBuffer", async (_, __, message: Buffer) =>
+        channel.send(message)
+      );
+      await done;
+    } else if (typeof options.blpop !== "undefined") {
+      await Promise.race([
+        (async () => {
+          while (!isDone) {
+            const result = await client.blpopBuffer(
+              toargs(options.blpop),
+              POP_TIMEOUT
+            );
+            if (result !== null) {
+              channel.send(result[1]);
+            }
+          }
+        })(),
+        done,
+      ]);
+    } else if (typeof options.brpop !== "undefined") {
+      await Promise.race([
+        (async () => {
+          while (!isDone) {
+            const result = await client.brpopBuffer(
+              toargs(options.brpop),
+              POP_TIMEOUT
+            );
+            if (result !== null) {
+              channel.send(result[1]);
+            }
+          }
+        })(),
+        done,
+      ]);
+    }
+  })();
+
+  // Assemble the event channel.
+  const stopConsuming: () => Promise<void> =
+    typeof options.subscribe !== "undefined"
+      ? async () => {
+          await client.unsubscribe(...toargs(options.subscribe));
+          notifyDone();
+        }
+      : typeof options.psubscribe !== "undefined"
+      ? async () => {
+          await client.punsubscribe(...toargs(options.psubscribe));
+          notifyDone();
+        }
+      : async () => {
+          notifyDone();
+        };
+  return [
+    parseChannel(
+      {
+        ...channel,
+        send: () => {
+          logger.warn("Can't send events to an input channel");
+          return false;
+        },
+        close: async () => {
+          await stopConsuming();
+          await client.quit();
+          await channel.close();
+          logger.debug("Drained redis input");
+        },
+      },
+      eventParser,
+      "parsing redis message"
+    ),
+    consuming,
+  ];
+};

--- a/src/input/redis.ts
+++ b/src/input/redis.ts
@@ -146,11 +146,11 @@ export const make = (
   const consuming = (async () => {
     if (typeof options.subscribe !== "undefined") {
       try {
-        await client.subscribe(...toargs(options.subscribe));
         client.on("message", (redisChannel: string, message: string) => {
           logger.debug("Got message from redis channel", redisChannel, message);
           channel.send(message);
         });
+        await client.subscribe(...toargs(options.subscribe));
         await done;
       } catch (err) {
         logger.error(`Couldn't subscribe to channel(s): ${err}`);
@@ -160,11 +160,11 @@ export const make = (
       }
     } else if (typeof options.psubscribe !== "undefined") {
       try {
-        await client.psubscribe(...toargs(options.psubscribe));
         client.on("pmessage", (_, redisChannel: string, message: string) => {
           logger.debug("Got message from redis channel", redisChannel, message);
           channel.send(message);
         });
+        await client.psubscribe(...toargs(options.psubscribe));
         await done;
       } catch (err) {
         logger.error(`Couldn't psubscribe to channel pattern(s): ${err}`);

--- a/src/input/stdin.ts
+++ b/src/input/stdin.ts
@@ -5,6 +5,7 @@ import {
   makeNewEventParser,
   parseChannel,
   WrapDirective,
+  wrapDirectiveSchema,
   chooseParser,
   makeWrapper,
 } from "../event";
@@ -15,6 +16,26 @@ import { makeLogger } from "../log";
  * A logger instance namespaced to this module.
  */
 const logger = makeLogger("input/stdin");
+
+/**
+ * Options for this input form.
+ */
+export type STDINInputOptions = { wrap?: WrapDirective } | null;
+
+/**
+ * An ajv schema for the options.
+ */
+export const optionsSchema = {
+  anyOf: [
+    {
+      type: "object",
+      properties: { wrap: wrapDirectiveSchema },
+      additionalProperties: false,
+      required: [],
+    },
+    { type: "null" },
+  ],
+};
 
 /**
  * Creates an input channel based on data coming from STDIN. Returns a
@@ -32,7 +53,7 @@ const logger = makeLogger("input/stdin");
 export const make = (
   pipelineName: string,
   pipelineSignature: string,
-  options: { wrap?: WrapDirective } | null
+  options: STDINInputOptions
 ): [Channel<never, Event>, Promise<void>] => {
   const parse = chooseParser(
     (typeof options === "string" ? {} : options)?.wrap

--- a/src/input/tail.ts
+++ b/src/input/tail.ts
@@ -73,7 +73,7 @@ export const make = (
   const startPos =
     typeof options === "string" ? "end" : options["start-at"] ?? "end";
   const eventParser = makeNewEventParser(pipelineName, pipelineSignature);
-  const queue = new AsyncQueue<unknown>();
+  const queue = new AsyncQueue<unknown>("input.tail");
   // Wrap the queue's channel to make it look like an input channel.
   let notifyDrained: () => void;
   const drained: Promise<void> = new Promise((resolve) => {

--- a/src/io/jq.ts
+++ b/src/io/jq.ts
@@ -113,7 +113,9 @@ export const makeChannel = async <T>(
   });
   await precondition;
   const parseStream = parse ?? parseJson;
-  const bufferChannel: Channel<T, T> = new AsyncQueue<T>().asChannel();
+  const bufferChannel: Channel<T, T> = new AsyncQueue<T>(
+    "io.jq.buffer"
+  ).asChannel();
   const feedEnded: Promise<void> = (async () => {
     for await (const value of bufferChannel.receive) {
       const flushed = child.stdin.write(JSON.stringify(value) + "\n");

--- a/src/io/redis.ts
+++ b/src/io/redis.ts
@@ -1,0 +1,70 @@
+import RedisClient from "ioredis";
+import { Redis, Cluster } from "ioredis";
+import { makeLogger } from "../log";
+
+/**
+ * A logger instance namespaced to this module.
+ */
+const logger = makeLogger("io/redis");
+
+/**
+ * Redis connection options.
+ */
+interface Options {
+  url: string | string[];
+  "address-map"?: Record<string, string>;
+}
+
+/**
+ * Default port to assume for redis connections.
+ */
+const DEFAULT_PORT = 6379;
+
+/**
+ * Wrap both connection types.
+ */
+export type RedisConnection = Redis | Cluster;
+
+/**
+ * Create a single instance or cluster client.
+ *
+ * @param options The options given for the connection.
+ * @returns A client object for a single instance or a cluster.
+ */
+export const connect = (options: Options): RedisConnection => {
+  let client: RedisConnection;
+  if (
+    Array.isArray(options.url) ||
+    typeof options["address-map"] !== "undefined"
+  ) {
+    client = new Cluster(
+      Array.isArray(options.url) ? options.url : [options.url],
+      typeof options["address-map"] === "undefined"
+        ? {}
+        : {
+            natMap: Object.fromEntries(
+              Object.entries(options["address-map"]).map(([key, address]) => {
+                // address is given as a string, and the library
+                // expects a (host, port) pair
+                const pair = address.split(":");
+                if (pair.length === 1) {
+                  return [key, { host: address, port: DEFAULT_PORT }];
+                }
+                const rawPort = pair[pair.length - 1];
+                return [
+                  key,
+                  {
+                    host: pair.slice(0, -1).join(":"),
+                    port: parseInt(rawPort, 10),
+                  },
+                ];
+              })
+            ),
+          }
+    );
+  } else {
+    client = new RedisClient(options.url);
+  }
+  client.on("error", (err: Error) => logger.warn(`redis client error: ${err}`));
+  return client;
+};

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -149,7 +149,7 @@ export const run = async (
   );
   // Initiate the central bus queue, a dead event list, and all the
   // steps.
-  const busQueue = new AsyncQueue<[number, Event]>();
+  const busQueue = new AsyncQueue<[number, Event]>("bus");
   const deadEvents: Event[] = [];
   const makeSender =
     (index: number) =>

--- a/src/step-functions/deduplicate.ts
+++ b/src/step-functions/deduplicate.ts
@@ -3,6 +3,34 @@ import { getSignature } from "../utils";
 import { Event } from "../event";
 
 /**
+ * Options for this function.
+ */
+export type DeduplicateFunctionOptions = {
+  ["consider-name"]?: boolean;
+  ["consider-data"]?: boolean;
+  ["consider-trace"]?: boolean;
+} | null;
+
+/**
+ * An ajv schema for the options.
+ */
+export const optionsSchema = {
+  anyOf: [
+    {
+      type: "object",
+      properties: {
+        "consider-name": { type: "boolean" },
+        "consider-data": { type: "boolean" },
+        "consider-trace": { type: "boolean" },
+      },
+      additionalProperties: false,
+      required: [],
+    },
+    { type: "null" },
+  ],
+};
+
+/**
  * Remove duplicate events from the given vector. The duplicate events
  * removed are never the first ones encountered for each event
  * identity.
@@ -45,11 +73,7 @@ export const make = async (
   pipelineName: string,
   pipelineSignature: string,
   /* eslint-enable @typescript-eslint/no-unused-vars */
-  options: {
-    ["consider-name"]?: boolean;
-    ["consider-data"]?: boolean;
-    ["consider-trace"]?: boolean;
-  } | null
+  options: DeduplicateFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   const queue = new AsyncQueue<Event[]>();
   const key = [

--- a/src/step-functions/deduplicate.ts
+++ b/src/step-functions/deduplicate.ts
@@ -75,7 +75,7 @@ export const make = async (
   /* eslint-enable @typescript-eslint/no-unused-vars */
   options: DeduplicateFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
-  const queue = new AsyncQueue<Event[]>();
+  const queue = new AsyncQueue<Event[]>("step.<?>.deduplicate");
   const key = [
     options?.["consider-name"] ?? true ? "1" : "0",
     options?.["consider-data"] ?? true ? "1" : "0",

--- a/src/step-functions/expose-http.ts
+++ b/src/step-functions/expose-http.ts
@@ -12,6 +12,52 @@ import { makeChannel } from "../io/jq";
 const logger = makeLogger("step-functions/expose-http");
 
 /**
+ * Options for this function.
+ */
+export type ExposeHTTPFunctionOptions = {
+  endpoint: string;
+  port: number | string;
+  responses: number | string;
+  headers?: { [key: string]: string | string[] };
+  ["jq-expr"]?: string;
+};
+
+/**
+ * An ajv schema for the options.
+ */
+export const optionsSchema = {
+  type: "object",
+  properties: {
+    endpoint: { type: "string", minLength: 1, pattern: "^/.*$" },
+    port: {
+      anyOf: [
+        { type: "integer", minimum: 1, maximum: 65535 },
+        { type: "string", pattern: "^[0-9]*[1-9][0-9]*$" },
+      ],
+    },
+    responses: {
+      anyOf: [
+        { type: "integer", minimum: 1 },
+        { type: "string", pattern: "^[0-9]*[1-9][0-9]*$" },
+      ],
+    },
+    headers: {
+      type: "object",
+      properties: {},
+      additionalProperties: {
+        anyOf: [
+          { type: "string" },
+          { type: "array", items: { type: "string" } },
+        ],
+      },
+    },
+    "jq-expr": { type: "string", minLength: 1 },
+  },
+  additionalProperties: false,
+  required: ["endpoint", "port", "responses"],
+};
+
+/**
  * Add a thing to the given fully-sized slice at the next index, given
  * that the current index points to a previous location in the slice.
  *
@@ -91,13 +137,7 @@ export const make = async (
   pipelineName: string,
   pipelineSignature: string,
   /* eslint-enable @typescript-eslint/no-unused-vars */
-  options: {
-    endpoint: string;
-    port: number | string;
-    responses: number | string;
-    headers?: { [key: string]: string | string[] };
-    ["jq-expr"]?: string;
-  }
+  options: ExposeHTTPFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   const endpoint = options.endpoint.endsWith("/")
     ? options.endpoint.slice(0, -1)

--- a/src/step-functions/expose-http.ts
+++ b/src/step-functions/expose-http.ts
@@ -181,7 +181,7 @@ export const make = async (
     );
   } else {
     responsesChannel = drain(
-      new AsyncQueue<Event[]>().asChannel(),
+      new AsyncQueue<Event[]>("step.<?>.expoes-http.accumulating").asChannel(),
       async (events: Event[]) => {
         const [key, response] = await makeEventWindowResponse(events);
         registerResponse(key, response);
@@ -247,7 +247,7 @@ export const make = async (
   const forwardingChannel = flatMap(async (events: Event[]) => {
     responsesChannel.send(events);
     return events;
-  }, new AsyncQueue<Event[]>().asChannel());
+  }, new AsyncQueue<Event[]>("step.<?>.expose-http.forward").asChannel());
   return {
     ...forwardingChannel,
     close: async () => {

--- a/src/step-functions/keep-when.ts
+++ b/src/step-functions/keep-when.ts
@@ -3,6 +3,16 @@ import { Event } from "../event";
 import { ajv } from "../utils";
 
 /**
+ * Options for this function.
+ */
+export type KeepWhenFunctionOptions = object;
+
+/**
+ * An ajv schema for the options.
+ */
+export const optionsSchema = { type: "object" };
+
+/**
  * Function that selects events according to a schema that is compared
  * with each event's data. Event's that don't match the schema are
  * dropped.
@@ -17,7 +27,7 @@ export const make = async (
   pipelineName: string,
   pipelineSignature: string,
   /* eslint-enable @typescript-eslint/no-unused-vars */
-  options: object
+  options: KeepWhenFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   const matchesSchema = ajv.compile(options);
   const queue = new AsyncQueue<Event[]>();

--- a/src/step-functions/keep-when.ts
+++ b/src/step-functions/keep-when.ts
@@ -30,7 +30,7 @@ export const make = async (
   options: KeepWhenFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   const matchesSchema = ajv.compile(options);
-  const queue = new AsyncQueue<Event[]>();
+  const queue = new AsyncQueue<Event[]>("step.<?>.keep-when");
   return flatMap(
     (events: Event[]) =>
       Promise.resolve(events.filter((event) => matchesSchema(event.data))),

--- a/src/step-functions/keep.ts
+++ b/src/step-functions/keep.ts
@@ -2,6 +2,21 @@ import { Channel, AsyncQueue, flatMap } from "../async-queue";
 import { Event } from "../event";
 
 /**
+ * Options for this function.
+ */
+export type KeepFunctionOptions = number | string;
+
+/**
+ * An ajv schema for the options.
+ */
+export const optionsSchema = {
+  anyOf: [
+    { type: "integer", minimum: 1 },
+    { type: "string", pattern: "^[0-9]*[1-9][0-9]*$" },
+  ],
+};
+
+/**
  * Function that selects a fixed number of events from each batch, and
  * drops the rest.
  *
@@ -16,7 +31,7 @@ export const make = async (
   pipelineName: string,
   pipelineSignature: string,
   /* eslint-enable @typescript-eslint/no-unused-vars */
-  options: number | string
+  options: KeepFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   const quantity =
     typeof options === "string" ? parseInt(options, 10) : options;

--- a/src/step-functions/keep.ts
+++ b/src/step-functions/keep.ts
@@ -35,7 +35,7 @@ export const make = async (
 ): Promise<Channel<Event[], Event>> => {
   const quantity =
     typeof options === "string" ? parseInt(options, 10) : options;
-  const queue = new AsyncQueue<Event[]>();
+  const queue = new AsyncQueue<Event[]>("step.<?>.keep");
   return flatMap(
     (events: Event[]) => Promise.resolve(events.slice(0, quantity)),
     queue.asChannel()

--- a/src/step-functions/rename.ts
+++ b/src/step-functions/rename.ts
@@ -2,6 +2,41 @@ import { Channel, AsyncQueue, flatMap } from "../async-queue";
 import { Event, makeFrom } from "../event";
 
 /**
+ * Options for this function.
+ */
+export type RenameFunctionOptions =
+  | {
+      append?: string;
+      prepend?: string;
+    }
+  | { replace: string };
+
+/**
+ * An ajv schema for the options.
+ */
+export const optionsSchema = {
+  anyOf: [
+    {
+      type: "object",
+      properties: {
+        append: { type: "string", minLength: 1 },
+        prepend: { type: "string", minLength: 1 },
+      },
+      additionalProperties: false,
+      required: [],
+    },
+    {
+      type: "object",
+      properties: {
+        replace: { type: "string", minLength: 1 },
+      },
+      additionalProperties: false,
+      required: ["replace"],
+    },
+  ],
+};
+
+/**
  * Function that renames events according to the specified options.
  *
  * @param pipelineName The name of the pipeline.
@@ -14,7 +49,7 @@ export const make = async (
   pipelineName: string,
   pipelineSignature: string,
   /* eslint-enable @typescript-eslint/no-unused-vars */
-  options: { append?: string; prepend?: string } | { replace: string }
+  options: RenameFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   const makeNewName: (name: string) => string =
     "replace" in options

--- a/src/step-functions/rename.ts
+++ b/src/step-functions/rename.ts
@@ -55,7 +55,7 @@ export const make = async (
     "replace" in options
       ? () => options.replace
       : (name) => (options.prepend ?? "") + name + (options.append ?? "");
-  const queue = new AsyncQueue<Event[]>();
+  const queue = new AsyncQueue<Event[]>("step.<?>.rename");
   return flatMap(
     (events: Event[]) =>
       Promise.all(

--- a/src/step-functions/send-file.ts
+++ b/src/step-functions/send-file.ts
@@ -17,6 +17,34 @@ const appendFile: (path: string, data: string) => Promise<void> =
 const logger = makeLogger("step-functions/send-file");
 
 /**
+ * Options for this function.
+ */
+export type SendFileFunctionOptions =
+  | string
+  | {
+      path: string;
+      ["jq-expr"]?: string;
+    };
+
+/**
+ * An ajv schema for the options.
+ */
+export const optionsSchema = {
+  anyOf: [
+    { type: "string", minLength: 1 },
+    {
+      type: "object",
+      properties: {
+        path: { type: "string", minLength: 1 },
+        "jq-expr": { type: "string", minLength: 1 },
+      },
+      additionalProperties: false,
+      required: ["path"],
+    },
+  ],
+};
+
+/**
  * Function that appends events to a file and forwards them to the
  * pipeline.
  *
@@ -31,7 +59,7 @@ export const make = async (
   pipelineName: string,
   pipelineSignature: string,
   /* eslint-enable @typescript-eslint/no-unused-vars */
-  options: string | { path: string; ["jq-expr"]?: string }
+  options: SendFileFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   const path = typeof options === "string" ? options : options.path;
   let forwarder: (events: Event[]) => void;

--- a/src/step-functions/send-file.ts
+++ b/src/step-functions/send-file.ts
@@ -83,7 +83,7 @@ export const make = async (
     closeExternal = jqChannel.close.bind(jqChannel);
   } else {
     const accumulatingChannel: Channel<Event[], never> = drain(
-      new AsyncQueue<Event[]>().asChannel(),
+      new AsyncQueue<Event[]>("step.<?>.send-file.accumulating").asChannel(),
       async (events: Event[]) => {
         const output =
           events.map((event) => JSON.stringify(event)).join("\n") + "\n";
@@ -97,7 +97,7 @@ export const make = async (
     forwarder = accumulatingChannel.send.bind(accumulatingChannel);
     closeExternal = accumulatingChannel.close.bind(accumulatingChannel);
   }
-  const queue = new AsyncQueue<Event[]>();
+  const queue = new AsyncQueue<Event[]>("step.<?>.send-file.forward");
   const forwardingChannel = flatMap(async (events: Event[]) => {
     forwarder(events);
     return events;

--- a/src/step-functions/send-http.ts
+++ b/src/step-functions/send-http.ts
@@ -102,7 +102,7 @@ export const make = async (
     closeExternal = jqChannel.close.bind(jqChannel);
   } else {
     const accumulatingChannel: Channel<Event[], never> = drain(
-      new AsyncQueue<Event[]>().asChannel(),
+      new AsyncQueue<Event[]>("step.<?>.send-http.accumulating").asChannel(),
       async (events: Event[]) => {
         requests[i++] = sendEvents(events, target, method, headers);
         if (i === concurrent) {
@@ -117,7 +117,7 @@ export const make = async (
     forwarder = accumulatingChannel.send.bind(accumulatingChannel);
     closeExternal = accumulatingChannel.close.bind(accumulatingChannel);
   }
-  const queue = new AsyncQueue<Event[]>();
+  const queue = new AsyncQueue<Event[]>("step.<?>.send-http.forward");
   const forwardingChannel = flatMap(async (events: Event[]) => {
     forwarder(events);
     return events;

--- a/src/step-functions/send-http.ts
+++ b/src/step-functions/send-http.ts
@@ -5,6 +5,55 @@ import { sendEvents, sendThing } from "../io/http-client";
 import { makeChannel } from "../io/jq";
 
 /**
+ * Options for this function.
+ */
+export type SendHTTPFunctionOptions =
+  | string
+  | {
+      target: string;
+      method?: "POST" | "PUT" | "PATCH";
+      ["jq-expr"]?: string;
+      headers?: { [key: string]: string | number | boolean };
+      concurrent?: number | string;
+    };
+
+/**
+ * An ajv schema for the options.
+ */
+export const optionsSchema = {
+  anyOf: [
+    { type: "string", minLength: 1 },
+    {
+      type: "object",
+      properties: {
+        target: { type: "string", minLength: 1 },
+        method: { enum: ["POST", "PUT", "PATCH"] },
+        "jq-expr": { type: "string", minLength: 1 },
+        headers: {
+          type: "object",
+          properties: {},
+          additionalProperties: {
+            anyOf: [
+              { type: "string" },
+              { type: "number" },
+              { type: "boolean" },
+            ],
+          },
+        },
+        concurrent: {
+          anyOf: [
+            { type: "integer", minimum: 1 },
+            { type: "string", pattern: "^[0-9]*[1-9][0-9]*$" },
+          ],
+        },
+      },
+      additionalProperties: false,
+      required: ["target"],
+    },
+  ],
+};
+
+/**
  * Function that sends events to a remote HTTP endpoint, ignores the
  * response and forwards the events to the pipeline.
  *
@@ -19,15 +68,7 @@ export const make = async (
   pipelineName: string,
   pipelineSignature: string,
   /* eslint-enable @typescript-eslint/no-unused-vars */
-  options:
-    | string
-    | {
-        target: string;
-        method?: "POST" | "PUT" | "PATCH";
-        ["jq-expr"]?: string;
-        headers?: { [key: string]: string | number | boolean };
-        concurrent?: number | string;
-      }
+  options: SendHTTPFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   const target = typeof options === "string" ? options : options.target;
   const method =

--- a/src/step-functions/send-receive-http.ts
+++ b/src/step-functions/send-receive-http.ts
@@ -87,7 +87,7 @@ export const make = async (
       jqChannel
     );
   } else {
-    const queue = new AsyncQueue<Event[]>();
+    const queue = new AsyncQueue<Event[]>("step.<?>.send-receive-http");
     return flatMap(
       (events: Event[]) =>
         sendReceiveEvents(

--- a/src/step-functions/send-receive-http.ts
+++ b/src/step-functions/send-receive-http.ts
@@ -1,7 +1,51 @@
 import { Channel, AsyncQueue, flatMap } from "../async-queue";
-import { Event, WrapDirective } from "../event";
+import { Event, WrapDirective, wrapDirectiveSchema } from "../event";
 import { sendReceiveEvents, sendReceiveThing } from "../io/http-client";
 import { makeChannel } from "../io/jq";
+
+/**
+ * Options for this function.
+ */
+export type SendReceiveHTTPFunctionOptions =
+  | string
+  | {
+      target: string;
+      method?: "POST" | "PUT" | "PATCH";
+      ["jq-expr"]?: string;
+      headers?: { [key: string]: string | number | boolean };
+      wrap?: WrapDirective;
+    };
+
+/**
+ * An ajv schema for the options.
+ */
+export const optionsSchema = {
+  anyOf: [
+    { type: "string", minLength: 1 },
+    {
+      type: "object",
+      properties: {
+        target: { type: "string", minLength: 1 },
+        method: { enum: ["POST", "PUT", "PATCH"] },
+        "jq-expr": { type: "string", minLength: 1 },
+        headers: {
+          type: "object",
+          properties: {},
+          additionalProperties: {
+            anyOf: [
+              { type: "string" },
+              { type: "number" },
+              { type: "boolean" },
+            ],
+          },
+        },
+        wrap: wrapDirectiveSchema,
+      },
+      additionalProperties: false,
+      required: ["target"],
+    },
+  ],
+};
 
 /**
  * Function that sends events to a remote HTTP endpoint, parses the
@@ -18,15 +62,7 @@ import { makeChannel } from "../io/jq";
 export const make = async (
   pipelineName: string,
   pipelineSignature: string,
-  options:
-    | string
-    | {
-        target: string;
-        method?: "POST" | "PUT" | "PATCH";
-        ["jq-expr"]?: string;
-        headers?: { [key: string]: string | number | boolean };
-        wrap?: WrapDirective;
-      }
+  options: SendReceiveHTTPFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   const target = typeof options === "string" ? options : options.target;
   const method =

--- a/src/step-functions/send-receive-jq.ts
+++ b/src/step-functions/send-receive-jq.ts
@@ -4,10 +4,39 @@ import {
   makeOldEventParser,
   parseChannel,
   WrapDirective,
+  wrapDirectiveSchema,
   chooseParser,
   makeWrapper,
 } from "../event";
 import { makeChannel } from "../io/jq";
+
+/**
+ * Options for this function.
+ */
+export type SendReceiveJqFunctionOptions =
+  | string
+  | {
+      ["jq-expr"]: string;
+      wrap?: WrapDirective;
+    };
+
+/**
+ * An ajv schema for the options.
+ */
+export const optionsSchema = {
+  anyOf: [
+    { type: "string", minLength: 1 },
+    {
+      type: "object",
+      properties: {
+        "jq-expr": { type: "string", minLength: 1 },
+        wrap: wrapDirectiveSchema,
+      },
+      additionalProperties: false,
+      required: ["jq-expr"],
+    },
+  ],
+};
 
 /**
  * Function that transforms events using jq.
@@ -20,7 +49,7 @@ import { makeChannel } from "../io/jq";
 export const make = async (
   pipelineName: string,
   pipelineSignature: string,
-  options: string | { ["jq-expr"]: string; wrap?: WrapDirective }
+  options: SendReceiveJqFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   const program = typeof options === "string" ? options : options["jq-expr"];
   const parse = chooseParser((typeof options === "string" ? {} : options).wrap);

--- a/src/step-functions/send-redis.ts
+++ b/src/step-functions/send-redis.ts
@@ -1,0 +1,157 @@
+import { AsyncQueue, Channel, flatMap, drain } from "../async-queue";
+import { Event } from "../event";
+import { makeLogger } from "../log";
+import { makeChannel } from "../io/jq";
+import { connect, RedisConnection } from "../io/redis";
+
+/**
+ * A logger instance namespaced to this module.
+ */
+const logger = makeLogger("step-functions/send-redis");
+
+/**
+ * Options for this function.
+ */
+export type SendRedisFunctionOptions = {
+  url: string | string[];
+  "address-map"?: Record<string, string>;
+  publish?: string;
+  rpush?: string;
+  lpush?: string;
+  ["jq-expr"]?: string;
+};
+
+/**
+ * Build a possible schema variation, to be combined with all other
+ * variations in an `anyOf`.
+ *
+ * @param key The variating key.
+ * @returns A partial schema.
+ */
+const buildSchema = (key: string): object => ({
+  type: "object",
+  properties: {
+    url: {
+      anyOf: [
+        { type: "string", minLength: 1 },
+        { type: "array", items: { type: "string", minLength: 1 }, minItems: 1 },
+      ],
+    },
+    "address-map": {
+      type: "object",
+      properties: {},
+      additionalProperties: { type: "string", minLength: 1 },
+      required: [],
+    },
+    [key]: {
+      type: "string",
+      minLength: 1,
+    },
+    "jq-expr": { type: "string", minLength: 1 },
+  },
+  additionalProperties: false,
+  required: ["url", key],
+});
+
+/**
+ * An ajv schema for the options.
+ */
+export const optionsSchema = {
+  anyOf: [buildSchema("publish"), buildSchema("rpush"), buildSchema("lpush")],
+};
+
+/**
+ * Sends a message to redis according to the given options.
+ *
+ * @param client The redis connection.
+ * @param options The sending options.
+ * @returns A function that will send any JSON-encodable thing to the
+ * redis instance or cluster.
+ */
+const sendMessage =
+  (client: RedisConnection, options: SendRedisFunctionOptions) =>
+  async (...messages: unknown[]): Promise<void> => {
+    if (typeof options.publish !== "undefined") {
+      try {
+        for (const message in messages) {
+          await client.publish(options.publish, JSON.stringify(message));
+        }
+      } catch (err) {
+        logger.warn(`Couldn't publish payload to redis: ${err}`);
+      }
+    } else if (typeof options.rpush !== "undefined") {
+      try {
+        await client.rpush(
+          options.rpush,
+          ...messages.map((message) => JSON.stringify(message))
+        );
+      } catch (err) {
+        logger.warn(`Couldn't rpush payload to redis: ${err}`);
+      }
+    } else if (typeof options.lpush !== "undefined") {
+      try {
+        await client.lpush(
+          options.lpush,
+          ...messages.map((message) => JSON.stringify(message))
+        );
+      } catch (err) {
+        logger.warn(`Couldn't lpush payload to redis: ${err}`);
+      }
+    } else {
+      logger.error("Misconfigured send-redis step function");
+    }
+  };
+
+/**
+ * Function that sends events to a redis instance, and forwards the
+ * same events to the rest of the pipeline unmodified.
+ *
+ * @param pipelineName The name of the pipeline.
+ * @param pipelineSignature The signature of the pipeline.
+ * @param options The options that indicate how to connect and send
+ * events to the redis instance.
+ * @returns A channel that forwards events to a redis instance.
+ */
+export const make = async (
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  pipelineName: string,
+  pipelineSignature: string,
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+  options: SendRedisFunctionOptions
+): Promise<Channel<Event[], Event>> => {
+  const client: RedisConnection = connect(options);
+  let forwarder: (events: Event[]) => void;
+  let closeExternal: () => Promise<void>;
+  if (typeof options["jq-expr"] === "string") {
+    const jqChannel: Channel<Event[], never> = drain(
+      await makeChannel(options["jq-expr"]),
+      sendMessage(client, options)
+    );
+    forwarder = jqChannel.send.bind(jqChannel);
+    closeExternal = jqChannel.close.bind(jqChannel);
+  } else {
+    const passThroughChannel: Channel<Event[], never> = drain(
+      new AsyncQueue<Event[]>().asChannel(),
+      async (events: Event[]) => {
+        await sendMessage(
+          client,
+          options
+        )(...events.map((event) => event.toJSON()));
+      }
+    );
+    forwarder = passThroughChannel.send.bind(passThroughChannel);
+    closeExternal = passThroughChannel.close.bind(passThroughChannel);
+  }
+  const queue = new AsyncQueue<Event[]>();
+  const forwardingChannel = flatMap(async (events: Event[]) => {
+    forwarder(events);
+    return events;
+  }, queue.asChannel());
+  return {
+    ...forwardingChannel,
+    close: async () => {
+      await forwardingChannel.close();
+      await closeExternal();
+    },
+  };
+};

--- a/src/step-functions/send-stdout.ts
+++ b/src/step-functions/send-stdout.ts
@@ -3,6 +3,30 @@ import { Event } from "../event";
 import { makeChannel } from "../io/jq";
 
 /**
+ * Options for this function.
+ */
+export type SendSTDOUTFunctionOptions = {
+  ["jq-expr"]?: string;
+} | null;
+
+/**
+ * An ajv schema for the options.
+ */
+export const optionsSchema = {
+  anyOf: [
+    {
+      type: "object",
+      properties: {
+        "jq-expr": { type: "string", minLength: 1 },
+      },
+      additionalProperties: false,
+      required: [],
+    },
+    { type: "null" },
+  ],
+};
+
+/**
  * Function that sends events to STDOUT and forwards them to the
  * pipeline.
  *
@@ -18,7 +42,7 @@ export const make = async (
   pipelineName: string,
   pipelineSignature: string,
   /* eslint-enable @typescript-eslint/no-unused-vars */
-  options: { ["jq-expr"]?: string } | null
+  options: SendSTDOUTFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   let forwarder: (events: Event[]) => void = (events: Event[]) =>
     events.forEach((event) => console.log(JSON.stringify(event)));

--- a/src/step-functions/send-stdout.ts
+++ b/src/step-functions/send-stdout.ts
@@ -61,7 +61,7 @@ export const make = async (
     forwarder = jqChannel.send.bind(jqChannel);
     closeExternal = jqChannel.close.bind(jqChannel);
   }
-  const queue = new AsyncQueue<Event[]>();
+  const queue = new AsyncQueue<Event[]>("step.<?>.send-stdout.forward");
   const forwardingChannel = flatMap(async (events: Event[]) => {
     forwarder(events);
     return events;

--- a/src/step.ts
+++ b/src/step.ts
@@ -70,7 +70,7 @@ type Group = { events: Event[]; timeout: ReturnType<typeof setTimeout> | null };
 export const makeWindowingChannel = (
   options: StepOptions
 ): Channel<Event, Event[]> => {
-  const queue = new AsyncQueue<Event[]>();
+  const queue = new AsyncQueue<Event[]>(`step.${options.name}.window`);
   const currentGroups: Map<number, Group> = new Map();
   let currentGroupIndex = 0;
   const timeWindow =


### PR DESCRIPTION
This PR adds a `redis` input form and a `redis` step function.

The input form receives events from a redis instance using one of four methods:
- [SUBSCRIBE](https://redis.io/commands/subscribe/)ing to one or more channels.
- [PSUBSCRIBE](https://redis.io/commands/psubscribe/)ing to one or more channel patterns.
- Repeatedly [BLPOP](https://redis.io/commands/blpop/)ing a key or keys.
- Repeatedly [BRPOP](https://redis.io/commands/brpop/)ing a key or keys.

The step function uses the reciprocals [PUBLISH](https://redis.io/commands/publish/), [RPUSH](https://redis.io/commands/rpush/), and [LPUSH](https://redis.io/commands/lpush/) to send events to a redis instance.