### PR TITLE
Feature/backpressure

### DIFF
--- a/examples/stress-test/README.md
+++ b/examples/stress-test/README.md
@@ -53,6 +53,11 @@ Optionally check the logs of the CDP program with:
 docker compose logs -f cdp
 ```
 
+Also consider altering the [`docker-compose.yml`](docker-compose.yml)
+file with [backpressure thresholds](/../../#backpressure) for the CDP
+service so that the pipeline avoids crashing by pausing the input
+channel.
+
 ## Get insights
 
 One common strategy to get a concrete result is to increase the

--- a/src/conf.ts
+++ b/src/conf.ts
@@ -285,3 +285,51 @@ export const HTTP_CLIENT_DEFAULT_CONCURRENCY: number =
     JSON.parse,
     compileThrowing({ type: "integer", minimum: 1 })
   ) ?? 10;
+
+/**
+ * Time interval, in seconds, between measurements taken to apply
+ * backpressure to input forms.
+ */
+export const BACKPRESSURE_INTERVAL: number =
+  fromEnv(
+    "BACKPRESSURE_INTERVAL",
+    JSON.parse,
+    compileThrowing({ type: "number", exclusiveMinimum: 0 })
+  ) ?? 5;
+
+/**
+ * Backpressure limit against the rss metric, measured in bytes.
+ */
+export const BACKPRESSURE_RSS: number | null = fromEnv(
+  "BACKPRESSURE_RSS",
+  JSON.parse,
+  compileThrowing({ type: "integer", minimum: 1 })
+);
+
+/**
+ * Backpressure limit against the heapTotal metric, measured in bytes.
+ */
+export const BACKPRESSURE_HEAP_TOTAL: number | null = fromEnv(
+  "BACKPRESSURE_HEAP_TOTAL",
+  JSON.parse,
+  compileThrowing({ type: "integer", minimum: 1 })
+);
+
+/**
+ * Backpressure limit against the heapUsed metric, measured in bytes.
+ */
+export const BACKPRESSURE_HEAP_USED: number | null = fromEnv(
+  "BACKPRESSURE_HEAP_USED",
+  JSON.parse,
+  compileThrowing({ type: "integer", minimum: 1 })
+);
+
+/**
+ * Backpressure limit against the queued events metric, measured in
+ * count of events.
+ */
+export const BACKPRESSURE_QUEUED_EVENTS: number | null = fromEnv(
+  "BACKPRESSURE_HEAP_USED",
+  JSON.parse,
+  compileThrowing({ type: "integer", minimum: 1 })
+);

--- a/src/conf.ts
+++ b/src/conf.ts
@@ -329,7 +329,7 @@ export const BACKPRESSURE_HEAP_USED: number | null = fromEnv(
  * count of events.
  */
 export const BACKPRESSURE_QUEUED_EVENTS: number | null = fromEnv(
-  "BACKPRESSURE_HEAP_USED",
+  "BACKPRESSURE_QUEUED_EVENTS",
   JSON.parse,
   compileThrowing({ type: "integer", minimum: 1 })
 );

--- a/src/input/poll.ts
+++ b/src/input/poll.ts
@@ -12,6 +12,7 @@ import {
 } from "../event";
 import { axiosInstance } from "../io/axios";
 import { makeLogger } from "../log";
+import { backpressure } from "../metrics";
 
 /**
  * A logger instance namespaced to this module.
@@ -98,6 +99,9 @@ export const make = (
   let latestETag: string | null = null;
   // One poll is a GET request to the target.
   const fetchOne = async () => {
+    if (backpressure.status()) {
+      return;
+    }
     try {
       const response = await axiosInstance.get(target, { headers });
       logger.debug(

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -84,6 +84,11 @@ export const backpressure = (() => {
       return state;
     },
     update(v: boolean) {
+      if (v && !state) {
+        logger.info("Pipeline is signalling backpressure");
+      } else if (!v && state) {
+        logger.info("Pipeline stopped signalling backpressure");
+      }
       state = v;
       return this;
     },

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,10 +1,16 @@
 import Koa from "koa";
 import client from "prom-client";
+import { match, P } from "ts-pattern";
 import { activeQueues } from "./async-queue";
 import {
   METRICS_EXPOSITION_PORT,
   METRICS_EXPOSITION_PATH,
   METRICS_NAME_PREFIX,
+  BACKPRESSURE_INTERVAL,
+  BACKPRESSURE_RSS,
+  BACKPRESSURE_HEAP_TOTAL,
+  BACKPRESSURE_HEAP_USED,
+  BACKPRESSURE_QUEUED_EVENTS,
 } from "./conf";
 import { makeLogger } from "./log";
 
@@ -36,6 +42,16 @@ export const stepEvents = new client.Counter({
 });
 
 /**
+ * Get a total count of queued events, in all queues.
+ *
+ * @returns The total count of queued events.
+ */
+const getQueuedEvents = (): number =>
+  Array.from(activeQueues)
+    .map((queue) => queue.data.length)
+    .reduce((a, b) => a + b, 0);
+
+/**
  * Tracks the count of queued events in any queue used for a pipeline
  * operation.
  */
@@ -43,11 +59,7 @@ export const queuedEvents = new client.Gauge({
   name: `${METRICS_NAME_PREFIX}queued_events`,
   help: "The count of queued events anywhere in a pipeline.",
   collect() {
-    this.set(
-      Array.from(activeQueues)
-        .map((queue) => queue.data.length)
-        .reduce((a, b) => a + b, 0)
-    );
+    this.set(getQueuedEvents());
   },
 });
 
@@ -61,19 +73,109 @@ export const deadEvents = new client.Gauge({
 });
 
 /**
+ * A global, boxed boolean value that gets updated according to a set
+ * of tracked metrics. The value indicates whether input forms should
+ * pause ingestion (true), or ingest freely (false).
+ */
+export const backpressure = (() => {
+  let state = false;
+  return {
+    status() {
+      return state;
+    },
+    update(v: boolean) {
+      state = v;
+      return this;
+    },
+  };
+})();
+
+/**
+ * Tracks the status of the backpressure global flag.
+ */
+export const backpressureMetric = new client.Gauge({
+  name: `${METRICS_NAME_PREFIX}backpressure`,
+  help: "Whether the pipeline is signaling backpressure.",
+  collect() {
+    this.set(backpressure.status() ? 1 : 0);
+  },
+});
+
+/**
+ * Helper to serialize measurement effect procedures, short-circuiting
+ * when one returns `true`.
+ *
+ * @param fns Procedures to compose into one.
+ * @returns A single composed procedure that mutates the
+ * `backpressure` state.
+ */
+const sequenceWatchers =
+  (fns: (() => boolean)[]): (() => void) =>
+  () => {
+    for (const fn of fns) {
+      if (fn()) {
+        backpressure.update(true);
+        return;
+      }
+    }
+    backpressure.update(false);
+  };
+
+/**
+ * Observe the configured metrics and update the backpressure global
+ * flag accordingly.
+ */
+const watchBackpressure = sequenceWatchers([
+  match([BACKPRESSURE_RSS, BACKPRESSURE_HEAP_TOTAL, BACKPRESSURE_HEAP_USED])
+    .with([null, null, null], () => () => false)
+    .with(
+      [P.not(null), null, null],
+      () => () => process.memoryUsage.rss() >= (BACKPRESSURE_RSS ?? 0)
+    )
+    .with(P._, () => () => {
+      const usage = process.memoryUsage();
+      if (BACKPRESSURE_RSS !== null && usage.rss >= BACKPRESSURE_RSS) {
+        return true;
+      }
+      if (
+        BACKPRESSURE_HEAP_TOTAL !== null &&
+        usage.heapTotal >= BACKPRESSURE_HEAP_TOTAL
+      ) {
+        return true;
+      }
+      if (
+        BACKPRESSURE_HEAP_USED !== null &&
+        usage.heapUsed >= BACKPRESSURE_HEAP_USED
+      ) {
+        return true;
+      }
+      return false;
+    })
+    .exhaustive(),
+  BACKPRESSURE_QUEUED_EVENTS !== null
+    ? () => getQueuedEvents() >= (BACKPRESSURE_QUEUED_EVENTS ?? 0)
+    : () => false,
+]);
+
+/**
  * Source:
  * https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md
  */
 const METRICS_CONTENT_TYPE = "text/plain; version=0.0.4";
 
 /**
- * Expose metrics using an HTTP server.
+ * Watch and expose metrics using an HTTP server. Also watch for
+ * backpressure events and notify them.
  *
  * @returns A procedure that finishes exposition.
  */
 export const startExposingMetrics = (): (() => Promise<void>) => {
+  const backpressureMeasurements = setInterval(
+    watchBackpressure,
+    BACKPRESSURE_INTERVAL * 1000
+  );
   if (METRICS_EXPOSITION_PATH.length === 0) {
-    return () => Promise.resolve();
+    return async () => clearInterval(backpressureMeasurements);
   }
   const server = new Koa()
     .use(async (ctx) => {
@@ -99,11 +201,13 @@ export const startExposingMetrics = (): (() => Promise<void>) => {
           `port ${METRICS_EXPOSITION_PORT} and path ${METRICS_EXPOSITION_PATH}`
       );
     });
-  return () =>
-    new Promise((resolve) =>
+  return () => {
+    clearInterval(backpressureMeasurements);
+    return new Promise((resolve) =>
       server.close(() => {
         logger.info("Finished metrics exposition");
         resolve();
       })
     );
+  };
 };


### PR DESCRIPTION
This PR adds the _backpressure_ mechanic, a self-triggered signal that can protect a pipeline from resource exhaustion, at the cost of pausing event ingestion.

Backpressure can be configured through environment variables `BACKPRESSURE_RSS`, `BACKPRESSURE_HEAP_TOTAL`, `BACKPRESSURE_HEAP_USED`, and `BACKPRESSURE_QUEUED_EVENTS`, all upper thresholds for various metrics. Backpressure is disabled by default.