### PR TITLE
Feature/mqtt

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,6 +841,44 @@ optional **number** or **string**, the priority set for each message.
 optional **boolean**, **"true"** or **"false"**, whether the message
 should survive broker restarts (provided the queue does too).
 
+**`steps.<name>.(reduce|flatmap).send-amqp.jq-expr`** optional
+**string**, an optional `jq` filter to apply to events before
+publishing them. If this option is used, each distinct value produced
+by the filter is used for a separate publish. If this option is not
+used, each event vector is published wholly, and the content type
+header of the message is forced to `application/x-ndjson`.
+
+#### `send-mqtt`
+
+**`steps.<name>.(reduce|flatmap).send-mqtt`** **string** or
+**object**, a function that always sends forward the events in the
+vectors it receives, unmodified. It also sends those vectors to the
+specified MQTT broker. If given a string, it will be interpreted as a
+URL and all other parameters will be set to their respective defaults.
+
+**`steps.<name>.(reduce|flatmap).send-mqtt.url`** required **string**,
+the URL of the broker to connect to.
+
+**`steps.<name>.(reduce|flatmap).send-mqtt.options`** optional
+**object**, the connection options. Check the
+[MQTT.js](https://github.com/mqttjs/MQTT.js#mqttclientstreambuilder-options)
+library for details.
+
+**`steps.<name>.(reduce|flatmap).send-mqtt.topic`** optional
+**string** the topic to publish messages to. If omitted, the client
+will publish to "cdp/*pipeline name*/*step name*".
+
+**`steps.<name>.(reduce|flatmap).send-mqtt.qos`** optional **0**,
+**1** or **2**, the quality of service to use when publishing
+messages. Defaults to **0**.
+
+**`steps.<name>.(reduce|flatmap).send-mqtt.jq-expr`** optional
+**string**, an optional `jq` filter to apply to events before
+publishing them. If this option is used, each distinct value produced
+by the filter is used for a separate publish. If this option is not
+used, each event vector is published wholly, and the content type
+header of the message is forced to `application/x-ndjson`.
+
 #### `send-redis`
 
 **`steps.<name>.(reduce|flatmap).send-redis`** **object**, a function

--- a/README.md
+++ b/README.md
@@ -291,30 +291,33 @@ incoming data as plain text, not JSON.
 
 #### `amqp`
 
-**`input.amqp`** **object**, the input form that makes the pipeline
-receive data from an AMQP broker using the AMQP 0-9-1 protocol
-(e.g. [RabbitMQ](https://www.rabbitmq.com/)).
+**`input.amqp`** **string** or **object**, the input form that makes
+the pipeline receive data from an AMQP broker using the AMQP 0-9-1
+protocol (e.g. [RabbitMQ](https://www.rabbitmq.com/)). If given a
+string, it will be interpreted as a URL and all other parameters will
+be set to their respective defaults.
 
 The `amqp` input form reacts to backpressure signals by not sending
 the message ACK back to the broker. This causes messages to be kept in
-queue. The `amqp` input form also periodically instructs the broker to
-"recover" non-acked messages so that they can be eventually consumed
-again, once the backpressure signal is turned off.
+queue. The `amqp` input form also instructs the broker to "recover"
+non-acked messages once backpressure is turned off, so that they can
+be eventually consumed again.
 
 **`input.amqp.url`** required **string**, the URL of the broker to
 connect to.
 
-**`input.amqp.exchange`** required **object**, the description of the
+**`input.amqp.exchange`** optional **object**, the description of the
 AMQP exchange to assert. For a description of AMQP exchanges, you may
 read the [AMQP 0-9-1 Model
 explanation](https://www.rabbitmq.com/tutorials/amqp-concepts.html) by
 RabbitMQ.
 
-**`input.amqp.exchange.name`** required **string**, the name of the
-AMQP exchange to assert.
+**`input.amqp.exchange.name`** optional **string**, the name of the
+AMQP exchange to assert. If omitted, it will default to `"cdp"`.
 
 **`input.amqp.exchange.type`** required **"direct"**, **"fanout"** or
-**"topic"**, the type of AMQP exchange to assert.
+**"topic"**, the type of AMQP exchange to assert. If omitted, it will
+default to `"topic"`.
 
 **`input.amqp.exchange.durable`** optional **boolean**, **"true"** or
 **"false"**, whether the exchange should be declared as _durable_ or
@@ -366,6 +369,52 @@ will be sent to the dead-letter exchange, if set.
 the maximum value for `priority`, if used. Check the
 [documentation](https://www.rabbitmq.com/priority.html) for more
 information.
+
+**`input.amqp.wrap`** optional **string** or **object**, a wrapping
+directive which specifies that incoming data is not encoded events,
+and thus should be wrapped.
+
+**`input.amqp.wrap.name`** required **string**, the name given to the
+events that wrap the input data.
+
+**`input.amqp.wrap.raw`** optional **boolean**, whether to treat
+incoming data as plain text, not JSON.
+
+#### `mqtt`
+
+**`input.mqtt`** **string** or **object**, the input form that makes
+the pipeline receive data from a MQTT broker. If given a string, it
+will be interpreted as a URL and all other parameters will be set to
+their respective defaults.
+
+The `mqtt` input form reacts to backpressure signals by delaying the
+message handling through the [MQTT.js library's
+`handleMessage`](https://github.com/mqttjs/MQTT.js#handleMessage)
+hook.
+
+**`input.mqtt.url`** required **string**, the URL of the broker to
+connect to.
+
+**`input.mqtt.options`** optional **object**, the connection
+options. Check the
+[MQTT.js](https://github.com/mqttjs/MQTT.js#mqttclientstreambuilder-options)
+library for details.
+
+**`input.mqtt.topic`** optional **string**, **list of string** or
+**object**, the topic or topics to subscribe to. If given as an
+object, the topic names will be the keys, and the values are QoS
+specifications of the form `{qos: 0 | 1 | 2}`. If omitted, the client
+will subscribe to `"cdp/#"`.
+
+**`input.mqtt.wrap`** optional **string** or **object**, a wrapping
+directive which specifies that incoming data is not encoded events,
+and thus should be wrapped.
+
+**`input.mqtt.wrap.name`** required **string**, the name given to the
+events that wrap the input data.
+
+**`input.mqtt.wrap.raw`** optional **boolean**, whether to treat
+incoming data as plain text, not JSON.
 
 #### `redis`
 
@@ -746,23 +795,26 @@ requests for the step. If omitted, it is set to the value of the
 
 #### `send-amqp`
 
-**`steps.<name>.(reduce|flatmap).send-amqp`** **object**, a function
-that always sends forward the events in the vectors it receives,
-unmodified. It also sends those vectors to the specified AMQP broker.
+**`steps.<name>.(reduce|flatmap).send-amqp`** **string** or
+**object**, a function that always sends forward the events in the
+vectors it receives, unmodified. It also sends those vectors to the
+specified AMQP broker. If given a string, it will be interpreted as a
+URL and all other parameters will be set to their respective defaults.
 
 **`steps.<name>.(reduce|flatmap).send-amqp.url`** required **string**,
 the URL of the broker to connect to.
 
-**`steps.<name>.(reduce|flatmap).send-amqp.exchange`** required
+**`steps.<name>.(reduce|flatmap).send-amqp.exchange`** optional
 **object**, the description of the AMQP exchange to assert, in the
 same shape as the [amqp input form](#amqp)'s.
 
-**`steps.<name>.(reduce|flatmap).send-amqp.exchange.name`** required
-**string**, the name f the AMQP exchange to assert.
+**`steps.<name>.(reduce|flatmap).send-amqp.exchange.name`** optional
+**string**, the name of the AMQP exchange to assert. If omitted, it
+will default to `"cdp"`.
 
-**`steps.<name>.(reduce|flatmap).send-amqp.exchange.type`** required
+**`steps.<name>.(reduce|flatmap).send-amqp.exchange.type`** optional
 **"direct"**, **"fanout"** or **"topic"**, the type of AMQP exchange
-to assert.
+to assert. If omitted, it will default to `"topic"`.
 
 **`steps.<name>.(reduce|flatmap).send-amqp.exchange.durable`**
 optional **boolean**, **"true"** or **"false"**, whether the exchange

--- a/__tests__/api.ts
+++ b/__tests__/api.ts
@@ -29,7 +29,7 @@ test("@standalone Pipeline template construction works normally", () => {
     name: "Test",
     input: { stdin: { wrap: { name: "lorem.ipsum", raw: true } } },
     steps: {
-      a: { reduce: { "send-stdout": {} } },
+      a: { reduce: { "send-http": "http://non-existent.org/events" } },
       b: { flatmap: { "keep-when": {} } },
       c: {
         after: ["a", "b"],

--- a/__tests__/input/mqtt.ts
+++ b/__tests__/input/mqtt.ts
@@ -1,0 +1,46 @@
+import { connect } from "mqtt";
+import { make } from "../../src/input/mqtt";
+import { resolveAfter } from "../../src/utils";
+import { consume } from "../test-utils";
+
+const brokerUrl = "mqtt://localhost:1883";
+
+const testEvents = [
+  { n: "foo", d: "fooo" },
+  { n: "bar", d: "barr" },
+  { n: "baz", d: "bazz" },
+];
+
+test("@mqtt The mqtt input form builds a one-way channel", async () => {
+  // Arrange
+  const [channel, stopped] = make("irrelevant", "irrelevant", brokerUrl);
+  // Act
+  const sent = channel.send();
+  await Promise.race([channel.close(), stopped]);
+  // Assert
+  expect(sent).toEqual(false);
+});
+
+test("@mqtt The mqtt input works as expected", async () => {
+  // Arrange
+  const client = connect(brokerUrl, {});
+  const [channel, stopped] = make("irrelevant", "irrelevant", {
+    url: brokerUrl,
+    topic: "test-input/2/+",
+  });
+  // Act
+  await resolveAfter(1000); // Give time for the subscription to be established
+  client.publish(
+    "test-input/2/loremipsum",
+    testEvents.map((e) => JSON.stringify(e)).join("\n")
+  );
+  client.end();
+  const [output] = await Promise.all([
+    consume(channel.receive),
+    Promise.race([resolveAfter(1000).then(() => channel.close()), stopped]),
+  ]);
+  // Assert
+  expect(output.map((e) => e.toJSON()).map(({ n, d }) => ({ n, d }))).toEqual(
+    testEvents
+  );
+});

--- a/__tests__/step-functions/deduplicate.ts
+++ b/__tests__/step-functions/deduplicate.ts
@@ -4,7 +4,7 @@ import { consume } from "../test-utils";
 
 test("@standalone Deduplicate works as expected", async () => {
   // Arrange
-  const channel = await make("irrelevant", "irrelevant", null);
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", null);
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
   const events = [
     await makeEvent("a", 3.14, trace),
@@ -28,7 +28,7 @@ test("@standalone Deduplicate works as expected", async () => {
 
 test("@standalone Deduplicate can consider specific parts of events", async () => {
   // Arrange
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     "consider-name": false,
     "consider-data": true,
     "consider-trace": false,

--- a/__tests__/step-functions/expose-http.ts
+++ b/__tests__/step-functions/expose-http.ts
@@ -6,7 +6,7 @@ import { consume } from "../test-utils";
 
 test("@standalone Expose-http works as expected", async () => {
   // Arrange
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     endpoint: "/events",
     port: 30000,
     responses: 2,
@@ -70,7 +70,7 @@ test("@standalone Expose-http works as expected", async () => {
 
 test("@standalone Expose-http can transform responses using a jq filter", async () => {
   // Arrange
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     endpoint: "/events",
     port: 30010,
     responses: 2,

--- a/__tests__/step-functions/keep-when.ts
+++ b/__tests__/step-functions/keep-when.ts
@@ -4,7 +4,9 @@ import { consume } from "../test-utils";
 
 test("@standalone Keep-when works as expected", async () => {
   // Arrange
-  const channel = await make("irrelevant", "irrelevant", { type: "object" });
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
+    type: "object",
+  });
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
   const events = [
     await makeEvent("not-an-object", 1, trace),

--- a/__tests__/step-functions/keep.ts
+++ b/__tests__/step-functions/keep.ts
@@ -4,7 +4,7 @@ import { consume } from "../test-utils";
 
 test("@standalone Keep works as expected", async () => {
   // Arrange
-  const channel = await make("irrelevant", "irrelevant", 3);
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", 3);
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
   const events = [
     await makeEvent("a", 1, trace),
@@ -28,7 +28,7 @@ test("@standalone Keep works as expected", async () => {
 
 test("@standalone Keep doesn't fail if the incoming event vector has fewer events", async () => {
   // Arrange
-  const channel = await make("irrelevant", "irrelevant", "3");
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", "3");
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
   const events = [
     await makeEvent("a", 1, trace),

--- a/__tests__/step-functions/rename.ts
+++ b/__tests__/step-functions/rename.ts
@@ -4,7 +4,7 @@ import { consume } from "../test-utils";
 
 test("@standalone Renaming with replacement works as expected", async () => {
   // Arrange
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     replace: "replaced",
   });
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
@@ -31,7 +31,7 @@ test("@standalone Renaming with replacement works as expected", async () => {
 
 test("@standalone Renaming with prepend works as expected", async () => {
   // Arrange
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     prepend: "prefix.",
   });
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
@@ -58,7 +58,7 @@ test("@standalone Renaming with prepend works as expected", async () => {
 
 test("@standalone Renaming with append works as expected", async () => {
   // Arrange
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     append: ".suffix",
   });
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
@@ -85,7 +85,7 @@ test("@standalone Renaming with append works as expected", async () => {
 
 test("@standalone Renaming with prepend and append works as expected", async () => {
   // Arrange
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     prepend: "prefix.",
     append: ".suffix",
   });

--- a/__tests__/step-functions/send-amqp.ts
+++ b/__tests__/step-functions/send-amqp.ts
@@ -27,7 +27,7 @@ test("@amqp Send-amqp works as expected on direct exchanges", async () => {
   // Arrange
   const receivedEvents: string[] = [];
   const conn = await makeConsumer("test1.output", "direct", receivedEvents);
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     url: brokerUrl,
     exchange: {
       name: "test1.output",
@@ -58,7 +58,7 @@ test("@amqp Send-amqp works as expected on fanout exchanges", async () => {
   // Arrange
   const receivedEvents: string[] = [];
   const conn = await makeConsumer("test2.output", "fanout", receivedEvents);
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     url: brokerUrl,
     exchange: {
       name: "test2.output",
@@ -89,7 +89,7 @@ test("@amqp Send-amqp works as expected on topic exchanges", async () => {
   // Arrange
   const receivedEvents: string[] = [];
   const conn = await makeConsumer("test3.output", "topic", receivedEvents);
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     url: brokerUrl,
     exchange: {
       name: "test3.output",
@@ -120,7 +120,7 @@ test("@amqp Send-amqp works as expected when using jq filters", async () => {
   // Arrange
   const receivedEvents: string[] = [];
   const conn = await makeConsumer("test4.output", "topic", receivedEvents);
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     url: brokerUrl,
     exchange: {
       name: "test4.output",

--- a/__tests__/step-functions/send-file.ts
+++ b/__tests__/step-functions/send-file.ts
@@ -33,7 +33,7 @@ test("@standalone Send-file works as expected", async () => {
   expect(fixtures.directory).not.toBeNull();
   const path = join(fixtures.directory as string, "test");
   // Arrange
-  const channel = await make("irrelevant", "irrelevant", path);
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", path);
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
   const events = [
     await makeEvent("a", "hello", trace),
@@ -56,7 +56,7 @@ test("@standalone Send-file works when using a jq program to preprocess the data
   expect(fixtures.directory).not.toBeNull();
   const path = join(fixtures.directory as string, "test");
   // Arrange
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     path,
     "jq-expr": ".[].d",
   });
@@ -82,7 +82,9 @@ test("@standalone Send-file doesn't overwrite file contents", async () => {
   const path = join(fixtures.directory as string, "test");
   writeFileSync(path, "this was here before those 'events' arrived");
   // Arrange
-  const channel = await make("irrelevant", "irrelevant", { path });
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
+    path,
+  });
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
   const events = [
     await makeEvent("a", "hello", trace),

--- a/__tests__/step-functions/send-http.ts
+++ b/__tests__/step-functions/send-http.ts
@@ -20,7 +20,10 @@ test("@standalone Send-http works as expected", async () => {
   // Arrange
   const target = "http://nothing";
   const method = "PATCH";
-  const channel = await make("irrelevant", "irrelevant", { target, method });
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
+    target,
+    method,
+  });
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
   const events = [
     await makeEvent("a", "hello", trace),
@@ -48,7 +51,7 @@ test("@standalone Send-http works when specifying a target plainly", async () =>
   // Arrange
   const target = "http://nothing";
   const method = "POST";
-  const channel = await make("irrelevant", "irrelevant", target);
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", target);
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
   const events = [
     await makeEvent("a", "hello", trace),
@@ -76,7 +79,7 @@ test("@standalone Send-http works when specifying a jq expression and headers", 
   // Arrange
   const target = "http://nothing";
   const method = "PUT";
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     target,
     method,
     "jq-expr": ".[].d",

--- a/__tests__/step-functions/send-mqtt.ts
+++ b/__tests__/step-functions/send-mqtt.ts
@@ -1,0 +1,84 @@
+import { connect } from "mqtt";
+import { make as makeEvent } from "../../src/event";
+import { make } from "../../src/step-functions/send-mqtt";
+import { resolveAfter } from "../../src/utils";
+import { consume } from "../test-utils";
+
+const brokerUrl = "mqtt://localhost:1883";
+
+// Initialize a MQTT subscriber for tests to use.
+const makeSubscriber = async (topic: string, receivedEvents: string[]) => {
+  const client = connect(brokerUrl, {});
+  await (new Promise((resolve, reject) => {
+    client.on("connect", () => {
+      client.subscribe(topic, (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }) as Promise<void>);
+  client.on("message", (_, message) => receivedEvents.push(message.toString()));
+  return client;
+};
+
+test("@mqtt Send-mqtt works as expected", async () => {
+  // Arrange
+  const receivedEvents: string[] = [];
+  const client = await makeSubscriber("test1/#", receivedEvents);
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
+    url: brokerUrl,
+    topic: "test1/loremipsum",
+  });
+  const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
+  const events = [
+    await makeEvent("a", "hello", trace),
+    await makeEvent("a", "world", trace),
+  ];
+  // Act
+  for (const event of events) {
+    channel.send([event]);
+  }
+  const [output] = await Promise.all([
+    consume(channel.receive),
+    channel.close(),
+  ]);
+  await resolveAfter(1000);
+  await (new Promise((resolve) =>
+    client.end(false, {}, () => resolve())
+  ) as Promise<void>);
+  // Assert
+  expect(output.map((e) => e.data)).toEqual(["hello", "world"]);
+  expect(receivedEvents).toEqual(events.map((e) => JSON.stringify(e) + "\n"));
+});
+
+test("@mqtt Send-mqtt works as expected when using jq filters", async () => {
+  // Arrange
+  const receivedEvents: string[] = [];
+  const client = await makeSubscriber("test2/#", receivedEvents);
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
+    url: brokerUrl,
+    topic: "test2/loremipsum",
+    "jq-expr": ".[].d",
+  });
+  const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
+  const events = [
+    await makeEvent("a", "hello", trace),
+    await makeEvent("a", "world", trace),
+  ];
+  // Act
+  channel.send(events);
+  const [output] = await Promise.all([
+    consume(channel.receive),
+    channel.close(),
+  ]);
+  await resolveAfter(1000);
+  await (new Promise((resolve) =>
+    client.end(false, {}, () => resolve())
+  ) as Promise<void>);
+  // Assert
+  expect(output.map((e) => e.data)).toEqual(["hello", "world"]);
+  expect(receivedEvents).toEqual(["hello", "world"]);
+});

--- a/__tests__/step-functions/send-receive-http.ts
+++ b/__tests__/step-functions/send-receive-http.ts
@@ -23,7 +23,7 @@ test("@standalone Send-receive-http works as expected", async () => {
   // Arrange
   const target = "http://nothing";
   const method = "POST";
-  const channel = await make("irrelevant", "irrelevant", target);
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", target);
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
   const events = [
     await makeEvent("a", "hello", trace),
@@ -52,7 +52,7 @@ test("@standalone Send-receive-http works when using jq as intermediary", async 
   // Arrange
   const target = "http://nothing";
   const method = "PATCH";
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     target,
     method,
     "jq-expr": `[.[] | . * {n: "changed"}]`,

--- a/__tests__/step-functions/send-receive-jq.ts
+++ b/__tests__/step-functions/send-receive-jq.ts
@@ -7,7 +7,7 @@ test("@standalone Send-receive-jq works as expected", async () => {
   // Arrange
   const pipelineName = "test";
   const pipelineSignature = "signature";
-  const channel = await make(pipelineName, pipelineSignature, {
+  const channel = await make(pipelineName, pipelineSignature, "irrelevant", {
     "jq-expr": `map(. * {d: "replaced!"})`,
   });
   const trace = [{ i: 1, p: pipelineName, h: pipelineSignature }];
@@ -32,6 +32,7 @@ test("@standalone Send-receive-jq will filter out events that are invalid", asyn
   const channel = await make(
     pipelineName,
     pipelineSignature,
+    "irrelevant",
     `[.[0] * {n: "invalid name"}] + .[1:]`
   );
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];

--- a/__tests__/step-functions/send-redis.ts
+++ b/__tests__/step-functions/send-redis.ts
@@ -10,7 +10,7 @@ test("@redis Send-redis works for single instance, publish", async () => {
   // Arrange
   const client = new Redis(redisUrl);
   await client.flushall();
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     instance: redisUrl,
     publish: "send-test1",
   });
@@ -38,7 +38,7 @@ test("@redis Send-redis works for single instance, rpush", async () => {
   // Arrange
   const client = new Redis(redisUrl);
   await client.flushall();
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     instance: redisUrl,
     rpush: "send-test2",
   });
@@ -68,7 +68,7 @@ test("@redis Send-redis works for single instance, lpush", async () => {
   // Arrange
   const client = new Redis(redisUrl);
   await client.flushall();
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     instance: redisUrl,
     lpush: "send-test3",
   });
@@ -98,7 +98,7 @@ test("@redis Send-redis works in tandem with jq", async () => {
   // Arrange
   const client = new Redis(redisUrl);
   await client.flushall();
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     instance: redisUrl,
     lpush: "send-test4",
     "jq-expr": ".[].d",
@@ -122,5 +122,5 @@ test("@redis Send-redis works in tandem with jq", async () => {
   await client.quit();
   // Assert
   expect(output.map((e) => e.data)).toEqual(["hello", "world"]);
-  expect(brpopResults).toEqual(['"hello"', '"world"']);
+  expect(brpopResults).toEqual(["hello", "world"]);
 });

--- a/__tests__/step-functions/send-stdout.ts
+++ b/__tests__/step-functions/send-stdout.ts
@@ -27,7 +27,7 @@ import { consume } from "../test-utils";
 
 test("@standalone Send-stdout works as expected", async () => {
   // Arrange
-  const channel = await make("irrelevant", "irrelevant", null);
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", null);
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];
   const events = [
     await makeEvent("a", "hello", trace),
@@ -48,7 +48,7 @@ test("@standalone Send-stdout works as expected", async () => {
 
 test("@standalone Send-stdout works when using a jq program to preprocess the data", async () => {
   // Arrange
-  const channel = await make("irrelevant", "irrelevant", {
+  const channel = await make("irrelevant", "irrelevant", "irrelevant", {
     "jq-expr": ".[].d",
   });
   const trace = [{ i: 1, p: "irrelevant", h: "irrelevant" }];

--- a/examples/composition/README.md
+++ b/examples/composition/README.md
@@ -8,7 +8,7 @@ composition available.
 The example is interactive. To run it, use:
 
 ```bash
-docker compose up -d redis rabbitmq
+docker compose up -d redis emqx rabbitmq
 sleep 5 # or wait a while for services to be ready
 docker compose up
 ```
@@ -22,7 +22,7 @@ curl --data-binary "@test-events.ndjson" "http://localhost:8000/events"
 
 Logs of interest will be visible on the first terminal, and they will
 refer to four instances of CDP: `first`, `second`, `third`, `fourth`,
-`fifth` and `sixth` (the name of the respective services in
+`fifth`, `sixth` and `seventh` (the name of the respective services in
 `docker-compose.yml`).
 
 To clean up, cancel the process in the first terminal with Ctrl-C and
@@ -36,13 +36,14 @@ docker compose down -v
 
 The example shows four pipelines that take input from an [HTTP
 input](/../../#http), [`tail` input](/../../#tail), [`poll`
-input](/../../#poll), [`redis` input](/../../#redis) and [`amqp`
-input](/../../#amqp) and execute some forwarding steps with the
-[`send-http`](/../../#send-http), [`send-file`](/../../#send-file),
+input](/../../#poll), [`redis` input](/../../#redis), [`amqp`
+input](/../../#amqp) and [`mqtt` input](/../../#mqtt) and execute some
+forwarding steps with the [`send-http`](/../../#send-http),
+[`send-file`](/../../#send-file),
 [`expose-http`](/../../#expose-http),
-[`send-redis`](/../../#send-redis) and
-[`send-amqp`](/../../#send-amqp) functions. Also, events are logged in
-each step showing the pipelines they've been in.
+[`send-redis`](/../../#send-redis), [`send-amqp`](/../../#send-amqp)
+and [`send-mqtt`](/../../#send-mqtt) functions. Also, events are
+logged in each step showing the pipelines they've been in.
 
 Worth noting is that the `second` and `fourth` services (and pipeline
 files) use _environment variable interpolation_, which is enabled
@@ -70,4 +71,7 @@ The pipeline files are named after the docker compose services:
   receives events from a redis PSUBSCRIBE subscription and forwards
   them to the `sixth` one via AMQP publishing.
 - [`pipline-sixth.yaml`](pipeline-sixth.yaml) is the pipeline that
-  receives events from an AMQP subscription.
+  receives events from an AMQP subscription and forwards them to the
+  `seventh` one via MQTT publishing.
+- [`pipeline-seventh.yaml`](pipeline-seventh.yaml) is the pipeline
+  that receives events from a MQTT subscription.

--- a/examples/composition/docker-compose.yml
+++ b/examples/composition/docker-compose.yml
@@ -52,9 +52,20 @@ services:
     command: ["/app/pipeline-sixth.yaml"]
     depends_on:
       - rabbitmq
+      - emqx
+      - seventh
+
+  seventh:
+    <<: *cdp
+    command: ["/app/pipeline-seventh.yaml"]
+    depends_on:
+      - emqx
 
   redis:
     image: redis:7-alpine
+
+  emqx:
+    image: emqx/emqx:4.3.16
 
   rabbitmq:
     image: rabbitmq:3-alpine

--- a/examples/composition/pipeline-seventh.yaml
+++ b/examples/composition/pipeline-seventh.yaml
@@ -1,0 +1,19 @@
+---
+name: "seventh"
+input:
+  mqtt:
+    url: mqtt://emqx:1883
+    topic: cdp/seventh/+
+
+steps:
+  debug:
+    flatmap:
+      send-stdout:
+        jq-expr: |-
+          [
+            .[].n, ": ",
+            (.[].d | if . == null then "<nothing>" else . end),
+            " (",
+            (.[].t | map(.p) | join(" --> ")),
+            ")"
+          ] | join("")

--- a/examples/composition/pipeline-sixth.yaml
+++ b/examples/composition/pipeline-sixth.yaml
@@ -20,3 +20,12 @@ steps:
             (.[].t | map(.p) | join(" --> ")),
             ")"
           ] | join("")
+
+  forward:
+    after:
+      - debug
+    flatmap:
+      send-mqtt:
+        url: mqtt://emqx:1883
+        topic: cdp/seventh/from-sixth
+        qos: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "commander": "^9.3.0",
         "ioredis": "^5.0.6",
         "koa": "^2.13.4",
+        "mqtt": "^4.3.7",
         "prom-client": "^14.0.1",
         "tail-file": "^1.4.15",
         "ts-pattern": "^4.0.3",
@@ -1861,8 +1862,26 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/bintrees": {
       "version": "1.0.2",
@@ -1895,11 +1914,60 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bl/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bl/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1973,11 +2041,33 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/buffer-more-ints": {
       "version": "1.0.0",
@@ -2139,11 +2229,81 @@
         "node": "^12.20.0 || >=14"
       }
     },
+    "node_modules/commist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
+      "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
+      "dependencies": {
+        "leven": "^2.1.0",
+        "minimist": "^1.1.0"
+      }
+    },
+    "node_modules/commist/node_modules/leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -2419,6 +2579,57 @@
         "node": ">=8"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/duplexify/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/duplexify/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2454,6 +2665,14 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/error-ex": {
@@ -3370,8 +3589,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -3442,7 +3660,6 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3557,6 +3774,55 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/help-me": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
+      "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
+      "dependencies": {
+        "glob": "^7.1.6",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/help-me/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/help-me/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/help-me/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -3658,6 +3924,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -3715,7 +4000,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4552,6 +4836,11 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-sdsl": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
+      "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4807,7 +5096,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4922,12 +5210,98 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+    },
+    "node_modules/mqtt": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.7.tgz",
+      "integrity": "sha512-ew3qwG/TJRorTz47eW46vZ5oBw5MEYbQZVaEji44j5lAUSQSqIEoul7Kua/BatBW0H0kKQcC9kwUHa1qzaWHSw==",
+      "dependencies": {
+        "commist": "^1.0.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.1.1",
+        "duplexify": "^4.1.1",
+        "help-me": "^3.0.0",
+        "inherits": "^2.0.3",
+        "lru-cache": "^6.0.0",
+        "minimist": "^1.2.5",
+        "mqtt-packet": "^6.8.0",
+        "number-allocator": "^1.0.9",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.6.0",
+        "reinterval": "^1.1.0",
+        "rfdc": "^1.3.0",
+        "split2": "^3.1.0",
+        "ws": "^7.5.5",
+        "xtend": "^4.0.2"
+      },
+      "bin": {
+        "mqtt": "bin/mqtt.js",
+        "mqtt_pub": "bin/pub.js",
+        "mqtt_sub": "bin/sub.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mqtt-packet": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
+      "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
+      "dependencies": {
+        "bl": "^4.0.2",
+        "debug": "^4.1.1",
+        "process-nextick-args": "^2.0.1"
+      }
+    },
+    "node_modules/mqtt/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/mqtt/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/mqtt/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/ms": {
@@ -4982,6 +5356,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/number-allocator": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.10.tgz",
+      "integrity": "sha512-K4AvNGKo9lP6HqsZyfSr9KDaqnwFzW203inhQEOwFrmFaYevpdX4VNwdOLk197aHujzbT//z6pCBrCOUYSM5iw==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "js-sdsl": "^2.1.2"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -5003,7 +5386,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5138,7 +5520,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5241,6 +5622,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/prom-client": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz",
@@ -5270,6 +5656,15 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -5351,6 +5746,11 @@
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
       }
+    },
+    "node_modules/reinterval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
+      "integrity": "sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -5439,6 +5839,11 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -5582,6 +5987,54 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "dependencies": {
+        "readable-stream": "^3.0.0"
+      }
+    },
+    "node_modules/split2/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/split2/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/split2/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -5621,6 +6074,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "node_modules/string_decoder": {
       "version": "0.10.31",
@@ -5983,6 +6441,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -6030,6 +6493,11 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
@@ -6180,8 +6648,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -6199,7 +6666,6 @@
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
       "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
-      "dev": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -6228,6 +6694,14 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -6240,8 +6714,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -7723,8 +8196,12 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bintrees": {
       "version": "1.0.2",
@@ -7756,11 +8233,45 @@
         }
       }
     },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7812,11 +8323,19 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "buffer-more-ints": {
       "version": "1.0.0",
@@ -7934,11 +8453,62 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
       "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw=="
     },
+    "commist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
+      "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
+      "requires": {
+        "leven": "^2.1.0",
+        "minimist": "^1.1.0"
+      },
+      "dependencies": {
+        "leven": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+          "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA=="
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -8145,6 +8715,42 @@
         }
       }
     },
+    "duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -8172,6 +8778,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -8764,8 +9378,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -8814,7 +9427,6 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -8888,6 +9500,40 @@
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
       "requires": {
         "has-symbols": "^1.0.2"
+      }
+    },
+    "help-me": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
+      "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
+      "requires": {
+        "glob": "^7.1.6",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
       }
     },
     "html-encoding-sniffer": {
@@ -8970,6 +9616,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -9006,7 +9657,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -9656,6 +10306,11 @@
         }
       }
     },
+    "js-sdsl": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
+      "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9863,7 +10518,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -9950,9 +10604,72 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+    },
+    "mqtt": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.7.tgz",
+      "integrity": "sha512-ew3qwG/TJRorTz47eW46vZ5oBw5MEYbQZVaEji44j5lAUSQSqIEoul7Kua/BatBW0H0kKQcC9kwUHa1qzaWHSw==",
+      "requires": {
+        "commist": "^1.0.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.1.1",
+        "duplexify": "^4.1.1",
+        "help-me": "^3.0.0",
+        "inherits": "^2.0.3",
+        "lru-cache": "^6.0.0",
+        "minimist": "^1.2.5",
+        "mqtt-packet": "^6.8.0",
+        "number-allocator": "^1.0.9",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.6.0",
+        "reinterval": "^1.1.0",
+        "rfdc": "^1.3.0",
+        "split2": "^3.1.0",
+        "ws": "^7.5.5",
+        "xtend": "^4.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
+    "mqtt-packet": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
+      "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
+      "requires": {
+        "bl": "^4.0.2",
+        "debug": "^4.1.1",
+        "process-nextick-args": "^2.0.1"
       }
     },
     "ms": {
@@ -9998,6 +10715,15 @@
         "path-key": "^3.0.0"
       }
     },
+    "number-allocator": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.10.tgz",
+      "integrity": "sha512-K4AvNGKo9lP6HqsZyfSr9KDaqnwFzW203inhQEOwFrmFaYevpdX4VNwdOLk197aHujzbT//z6pCBrCOUYSM5iw==",
+      "requires": {
+        "debug": "^4.3.1",
+        "js-sdsl": "^2.1.2"
+      }
+    },
     "nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -10016,7 +10742,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -10114,8 +10839,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-key": {
       "version": "3.1.1",
@@ -10187,6 +10911,11 @@
         }
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "prom-client": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz",
@@ -10210,6 +10939,15 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -10262,6 +11000,11 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
+    },
+    "reinterval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
+      "integrity": "sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ=="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -10324,6 +11067,11 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
+    },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -10426,6 +11174,39 @@
         "source-map": "^0.6.0"
       }
     },
+    "split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "requires": {
+        "readable-stream": "^3.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -10458,6 +11239,11 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "string_decoder": {
       "version": "0.10.31",
@@ -10709,6 +11495,11 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -10746,6 +11537,11 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -10865,8 +11661,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "write-file-atomic": {
       "version": "3.0.3",
@@ -10884,7 +11679,6 @@
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
       "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
-      "dev": true,
       "requires": {}
     },
     "xml-name-validator": {
@@ -10899,6 +11693,11 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -10908,8 +11707,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "src/index.ts",
   "scripts": {
     "start-rabbitmq": "docker start cdp-rabbitmq || docker run --rm -p 5672:5672 --name cdp-rabbitmq -d rabbitmq:3-alpine",
+    "start-emqx": "docker start cdp-emqx || docker run --rm -p 1883:1883 --name cdp-emqx -d emqx/emqx:4.3.16",
     "start-redis": "docker start cdp-redis || docker run --rm -p 6379:6379 --name cdp-redis -d redis:7-alpine",
-    "pretest": "npm run start-redis && npm run start-rabbitmq",
+    "pretest": "npm run start-redis && npm run start-emqx && npm run start-rabbitmq",
     "test": "jest -i --coverage",
-    "posttest": "docker stop cdp-redis cdp-rabbitmq",
+    "posttest": "docker stop cdp-redis cdp-emqx cdp-rabbitmq",
     "check": "jest -i -t @standalone && eslint . --ext .ts && tsc",
     "build": "esbuild src/index.ts --bundle --minify --platform=node --target=node16 --outdir=build",
     "check-and-build": "npm run check && npm run build"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "commander": "^9.3.0",
     "ioredis": "^5.0.6",
     "koa": "^2.13.4",
+    "mqtt": "^4.3.7",
     "prom-client": "^14.0.1",
     "tail-file": "^1.4.15",
     "ts-pattern": "^4.0.3",

--- a/src/api.ts
+++ b/src/api.ts
@@ -27,6 +27,8 @@ import * as pollInputModule from "./input/poll";
 import { PollInputOptions } from "./input/poll";
 import * as amqpInputModule from "./input/amqp";
 import { AMQPInputOptions } from "./input/amqp";
+import * as mqttInputModule from "./input/mqtt";
+import { MQTTInputOptions } from "./input/mqtt";
 import * as redisInputModule from "./input/redis";
 import { RedisInputOptions } from "./input/redis";
 // Step functions
@@ -86,6 +88,7 @@ const inputModules = {
   http: httpInputModule,
   poll: pollInputModule,
   amqp: amqpInputModule,
+  mqtt: mqttInputModule,
   redis: redisInputModule,
 };
 
@@ -99,6 +102,7 @@ type InputTemplate =
   | { http: HTTPInputOptions }
   | { poll: PollInputOptions }
   | { amqp: AMQPInputOptions }
+  | { mqtt: MQTTInputOptions }
   | { redis: RedisInputOptions };
 const inputTemplateSchema = {
   anyOf: Object.entries(inputModules).map(([key, mod]) =>

--- a/src/api.ts
+++ b/src/api.ts
@@ -44,6 +44,8 @@ import * as exposeHTTPFunctionModule from "./step-functions/expose-http";
 import { ExposeHTTPFunctionOptions } from "./step-functions/expose-http";
 import * as sendAMQPFunctionModule from "./step-functions/send-amqp";
 import { SendAMQPFunctionOptions } from "./step-functions/send-amqp";
+import * as sendMQTTFunctionModule from "./step-functions/send-mqtt";
+import { SendMQTTFunctionOptions } from "./step-functions/send-mqtt";
 import * as sendRedisFunctionModule from "./step-functions/send-redis";
 import { SendRedisFunctionOptions } from "./step-functions/send-redis";
 import * as sendHTTPFunctionModule from "./step-functions/send-http";
@@ -123,6 +125,7 @@ const stepFunctionModules = {
   "send-file": sendFileFunctionModule,
   "send-http": sendHTTPFunctionModule,
   "send-amqp": sendAMQPFunctionModule,
+  "send-mqtt": sendMQTTFunctionModule,
   "send-redis": sendRedisFunctionModule,
   "expose-http": exposeHTTPFunctionModule,
   "send-receive-jq": sendReceiveJqFunctionModule,
@@ -141,6 +144,7 @@ type StepFunctionTemplate =
   | { "send-file": SendFileFunctionOptions }
   | { "send-http": SendHTTPFunctionOptions }
   | { "send-amqp": SendAMQPFunctionOptions }
+  | { "send-mqtt": SendMQTTFunctionOptions }
   | { "send-redis": SendRedisFunctionOptions }
   | { "expose-http": ExposeHTTPFunctionOptions }
   | { "send-receive-jq": SendReceiveJqFunctionOptions }
@@ -351,7 +355,7 @@ export const runPipeline = async (
     )[0];
     const fn = await stepFunctionModules[
       stepFunctionName as keyof typeof stepFunctionModules
-    ].make(template.name, signature, stepFunctionOptions);
+    ].make(template.name, signature, name, stepFunctionOptions);
     const factory = makeWindowed(options, fn);
     steps.push({
       name,

--- a/src/input/amqp.ts
+++ b/src/input/amqp.ts
@@ -23,13 +23,13 @@ import { check, makeFuse } from "../utils";
 const logger = makeLogger("input/amqp");
 
 /**
- * Options for this input form.
+ * Extended connection options.
  */
-export interface AMQPInputOptions {
+interface ExtendedAMQPInputOptions {
   url: string;
-  exchange: {
-    name: string;
-    type: "direct" | "fanout" | "topic";
+  exchange?: {
+    name?: string;
+    type?: "direct" | "fanout" | "topic";
     durable?: boolean | "true" | "false";
     "auto-delete"?: boolean | "true" | "false";
   };
@@ -48,67 +48,81 @@ export interface AMQPInputOptions {
 }
 
 /**
+ * Options for this input form.
+ */
+export type AMQPInputOptions = string | ExtendedAMQPInputOptions;
+
+/**
  * An ajv schema for the options.
  */
 export const optionsSchema = {
-  type: "object",
-  properties: {
-    url: { type: "string", pattern: "^amqps?://.*$" },
-    exchange: {
+  anyOf: [
+    { type: "string", pattern: "^amqps?://.*$" },
+    {
       type: "object",
       properties: {
-        name: { type: "string", minLength: 1 },
-        type: { enum: ["direct", "fanout", "topic"] },
-        durable: { anyOf: [{ type: "boolean" }, { enum: ["true", "false"] }] },
-        "auto-delete": {
-          anyOf: [{ type: "boolean" }, { enum: ["true", "false"] }],
+        url: { type: "string", pattern: "^amqps?://.*$" },
+        exchange: {
+          type: "object",
+          properties: {
+            name: { type: "string", minLength: 1 },
+            type: { enum: ["direct", "fanout", "topic"] },
+            durable: {
+              anyOf: [{ type: "boolean" }, { enum: ["true", "false"] }],
+            },
+            "auto-delete": {
+              anyOf: [{ type: "boolean" }, { enum: ["true", "false"] }],
+            },
+          },
+          additionalProperties: false,
+          required: [],
         },
+        "binding-pattern": { type: "string" },
+        queue: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            durable: {
+              anyOf: [{ type: "boolean" }, { enum: ["true", "false"] }],
+            },
+            "auto-delete": {
+              anyOf: [{ type: "boolean" }, { enum: ["true", "false"] }],
+            },
+            "message-ttl": {
+              anyOf: [
+                { type: "integer", minimum: 0, maximum: 4294967295 },
+                { type: "string", pattern: "^[0-9]+$" },
+              ],
+            },
+            expires: {
+              anyOf: [
+                { type: "integer", minimum: 1, maximum: 4294967295 },
+                { type: "string", pattern: "^[0-9]*[1-9][0-9]*$" },
+              ],
+            },
+            "dead-letter-exchange": { type: "string", minLength: 1 },
+            "max-length": {
+              anyOf: [
+                { type: "integer", minimum: 1 },
+                { type: "string", pattern: "^[0-9]*[1-9][0-9]*$" },
+              ],
+            },
+            "max-priority": {
+              anyOf: [
+                { type: "integer", minimum: 0, maximum: 255 },
+                { type: "string", pattern: "^[0-9]+$" },
+              ],
+            },
+          },
+          additionalProperties: false,
+          required: [],
+        },
+        wrap: wrapDirectiveSchema,
       },
       additionalProperties: false,
-      required: ["name", "type"],
+      required: ["url"],
     },
-    "binding-pattern": { type: "string" },
-    queue: {
-      type: "object",
-      properties: {
-        name: { type: "string" },
-        durable: { anyOf: [{ type: "boolean" }, { enum: ["true", "false"] }] },
-        "auto-delete": {
-          anyOf: [{ type: "boolean" }, { enum: ["true", "false"] }],
-        },
-        "message-ttl": {
-          anyOf: [
-            { type: "integer", minimum: 0, maximum: 4294967295 },
-            { type: "string", pattern: "^[0-9]+$" },
-          ],
-        },
-        expires: {
-          anyOf: [
-            { type: "integer", minimum: 1, maximum: 4294967295 },
-            { type: "string", pattern: "^[0-9]*[1-9][0-9]*$" },
-          ],
-        },
-        "dead-letter-exchange": { type: "string", minLength: 1 },
-        "max-length": {
-          anyOf: [
-            { type: "integer", minimum: 1 },
-            { type: "string", pattern: "^[0-9]*[1-9][0-9]*$" },
-          ],
-        },
-        "max-priority": {
-          anyOf: [
-            { type: "integer", minimum: 0, maximum: 255 },
-            { type: "string", pattern: "^[0-9]+$" },
-          ],
-        },
-      },
-      additionalProperties: false,
-      required: [],
-    },
-    wrap: wrapDirectiveSchema,
-  },
-  additionalProperties: false,
-  required: ["url", "exchange"],
+  ],
 };
 
 /**
@@ -147,6 +161,12 @@ export const validate = (options: AMQPInputOptions): void => {
 };
 
 /**
+ * Default assertion values for the AMQP exchange.
+ */
+const DEFAULT_EXCHANGE_NAME = "cdp";
+const DEFAULT_EXCHANGE_TYPE = "topic";
+
+/**
  * Creates an input channel based on data received from an AMQP
  * broker, dispatched to a queue bound to a channel.
  *
@@ -154,8 +174,8 @@ export const validate = (options: AMQPInputOptions): void => {
  * input.
  * @param pipelineSignature The signature of the pipeline that will
  * use this input.
- * @param options The AMQP connection options to configure the input
- * channel.
+ * @param variantOptions The AMQP connection options to configure the
+ * input channel.
  * @returns A channel that receives data from an AMQP broker and
  * forwards parsed events, and a promise that resolves when the input
  * ends for any reason.
@@ -163,10 +183,18 @@ export const validate = (options: AMQPInputOptions): void => {
 export const make = (
   pipelineName: string,
   pipelineSignature: string,
-  options: AMQPInputOptions
+  variantOptions: AMQPInputOptions
 ): [Channel<never, Event>, Promise<void>] => {
-  const parse = chooseParser(options.wrap);
-  const wrapper = makeWrapper(options.wrap);
+  const options: ExtendedAMQPInputOptions =
+    typeof variantOptions === "string"
+      ? { url: variantOptions }
+      : variantOptions;
+  const parse = chooseParser(
+    (typeof options === "string" ? {} : options)?.wrap
+  );
+  const wrapper = makeWrapper(
+    (typeof options === "string" ? {} : options)?.wrap
+  );
   const eventParser = makeNewEventParser(pipelineName, pipelineSignature);
 
   const channel = flatMap(async (message: string) => {
@@ -189,17 +217,17 @@ export const make = (
       ch.on("close", () => done.trigger());
       ch.on("error", () => done.trigger());
       const { exchange } = await ch.assertExchange(
-        options.exchange.name,
-        options.exchange.type,
+        options.exchange?.name ?? DEFAULT_EXCHANGE_NAME,
+        options.exchange?.type ?? DEFAULT_EXCHANGE_TYPE,
         {
           durable:
-            typeof options.exchange.durable === "string"
-              ? options.exchange.durable === "true"
-              : options.exchange.durable ?? true,
+            typeof options.exchange?.durable === "string"
+              ? options.exchange?.durable === "true"
+              : options.exchange?.durable ?? true,
           autoDelete:
-            typeof options.exchange["auto-delete"] === "string"
-              ? options.exchange["auto-delete"] === "true"
-              : options.exchange["auto-delete"] ?? false,
+            typeof options.exchange?.["auto-delete"] === "string"
+              ? options.exchange?.["auto-delete"] === "true"
+              : options.exchange?.["auto-delete"] ?? false,
         }
       );
       const { queue } = await ch.assertQueue(options.queue?.name ?? "", {
@@ -251,7 +279,9 @@ export const make = (
         queue,
         exchange,
         options["binding-pattern"] ??
-          { direct: "cdp", fanout: "", topic: "#" }[options.exchange.type]
+          { direct: "cdp", fanout: "", topic: "#" }[
+            options.exchange?.type ?? DEFAULT_EXCHANGE_TYPE
+          ]
       );
 
       const { consumerTag } = await ch.consume(queue, (message) => {

--- a/src/input/mqtt.ts
+++ b/src/input/mqtt.ts
@@ -159,6 +159,8 @@ export const make = (
       if (err) {
         logger.error(`Error when subscribing to MQTT topic(s): ${err}`);
         done.trigger();
+      } else {
+        logger.debug("MQTT client subscribed successfully");
       }
     });
   });

--- a/src/input/mqtt.ts
+++ b/src/input/mqtt.ts
@@ -1,0 +1,198 @@
+import { Readable } from "stream";
+import { IClientOptions, connect } from "mqtt";
+import { match, P } from "ts-pattern";
+import { AsyncQueue, Channel, flatMap } from "../async-queue";
+import {
+  Event,
+  arrivalTimestamp,
+  makeNewEventParser,
+  parseChannel,
+  WrapDirective,
+  wrapDirectiveSchema,
+  chooseParser,
+  makeWrapper,
+  validateWrap,
+} from "../event";
+import { makeLogger } from "../log";
+import { backpressure } from "../metrics";
+import { check, makeFuse } from "../utils";
+
+/**
+ * A logger instance namespaced to this module.
+ */
+const logger = makeLogger("input/mqtt");
+
+/**
+ * Options for this input form.
+ */
+export type MQTTInputOptions =
+  | string
+  | {
+      url: string;
+      options?: IClientOptions;
+      topic?: string | string[] | Record<string, { qos: 0 | 1 | 2 }>;
+      wrap?: WrapDirective;
+    };
+
+/**
+ * An ajv schema for the options.
+ */
+export const optionsSchema = {
+  anyOf: [
+    { type: "string", minLength: 1 },
+    {
+      type: "object",
+      properties: {
+        url: { type: "string", minLength: 1 },
+        options: { type: "object" },
+        topic: {
+          anyOf: [
+            { type: "string", minLength: 1 },
+            {
+              type: "array",
+              items: { type: "string", minLength: 1 },
+              minItems: 1,
+            },
+            {
+              type: "object",
+              properties: {},
+              minProperties: 1,
+              propertyNames: { minLength: 1 },
+              additionalProperties: {
+                type: "object",
+                properties: { qos: { enum: [0, 1, 2] } },
+                additionalProperties: false,
+                required: ["qos"],
+              },
+            },
+          ],
+        },
+        wrap: wrapDirectiveSchema,
+      },
+      additionalProperties: false,
+      required: ["url"],
+    },
+  ],
+};
+
+/**
+ * Validate mqtt input options, after they've been checked by the ajv
+ * schema.
+ *
+ * @param options The options to validate.
+ */
+export const validate = (options: MQTTInputOptions): void => {
+  // TODO: validate mqtt connection options
+  check(
+    match(options).with({ wrap: P.select() }, (wrap) =>
+      validateWrap(wrap, "the input's wrap option")
+    )
+  );
+};
+
+/**
+ * Default topic to subscribe to, when no topic is specified.
+ */
+const DEFAULT_TOPIC = "cdp/#";
+
+/**
+ * Creates an input channel based on data received from a MQTT broker.
+ *
+ * @param pipelineName The name of the pipeline that will use this
+ * input.
+ * @param pipelineSignature The signature of the pipeline that will
+ * use this input.
+ * @param options The MQTT connection options to configure the input
+ * channel.
+ * @returns A channel that receives data from a MQTT broker and
+ * forwards parsed events, and a promise that resolves when the input
+ * ends for any reason.
+ */
+export const make = (
+  pipelineName: string,
+  pipelineSignature: string,
+  options: MQTTInputOptions
+): [Channel<never, Event>, Promise<void>] => {
+  const url = typeof options === "string" ? options : options.url;
+  const topic =
+    typeof options === "string"
+      ? DEFAULT_TOPIC
+      : options.topic ?? DEFAULT_TOPIC;
+  const parse = chooseParser(
+    (typeof options === "string" ? {} : options)?.wrap
+  );
+  const wrapper = makeWrapper(
+    (typeof options === "string" ? {} : options)?.wrap
+  );
+  const eventParser = makeNewEventParser(pipelineName, pipelineSignature);
+
+  const channel = flatMap(async (message: string) => {
+    arrivalTimestamp.update();
+    const things = [];
+    for await (const thing of parse(Readable.from([message]))) {
+      things.push(wrapper(thing));
+    }
+    return things;
+  }, new AsyncQueue<string>("input.mqtt").asChannel());
+  const done = makeFuse();
+
+  const client =
+    typeof options === "string" || typeof options.options === "undefined"
+      ? connect(url)
+      : connect(url, options.options);
+  // Emit backpressure as documented here:
+  // https://github.com/mqttjs/MQTT.js#mqttclienthandlemessagepacket-callback
+  client.handleMessage = (_, callback) => {
+    if (backpressure.status()) {
+      backpressure.once("off", () => callback());
+    } else {
+      callback();
+    }
+  };
+  client.on("error", (err) => {
+    logger.error(`MQTT client notified an error: ${err}`);
+    done.trigger();
+  });
+  client.on("connect", () => {
+    logger.debug("MQTT client connected successfully");
+    client.subscribe(topic, (err) => {
+      if (err) {
+        logger.error(`Error when subscribing to MQTT topic(s): ${err}`);
+        done.trigger();
+      }
+    });
+  });
+  client.on("message", (topic, message) => {
+    logger.debug("Got message from MQTT topic", topic, ":", message);
+    channel.send(message.toString());
+  });
+
+  const consuming = done.promise.then(
+    () =>
+      new Promise((resolve) =>
+        client.end(false, {}, () => resolve())
+      ) as Promise<void>
+  );
+
+  // Assemble the event channel.
+  return [
+    parseChannel(
+      {
+        ...channel,
+        send: () => {
+          logger.warn("Can't send events to an input channel");
+          return false;
+        },
+        close: async () => {
+          done.trigger();
+          await consuming;
+          await channel.close();
+          logger.debug("Drained mqtt input");
+        },
+      },
+      eventParser,
+      "parsing mqtt message"
+    ),
+    consuming,
+  ];
+};

--- a/src/step-functions/deduplicate.ts
+++ b/src/step-functions/deduplicate.ts
@@ -75,6 +75,7 @@ const deduplicate = async (
  *
  * @param pipelineName The name of the pipeline.
  * @param pipelineSignature The signature of the pipeline.
+ * @param stepName The name of the step this function belongs to.
  * @param options The options that indicate how to deduplicate
  * events.
  * @returns A channel that removes event duplicates.
@@ -84,9 +85,10 @@ export const make = async (
   pipelineName: string,
   pipelineSignature: string,
   /* eslint-enable @typescript-eslint/no-unused-vars */
+  stepName: string,
   options: DeduplicateFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
-  const queue = new AsyncQueue<Event[]>("step.<?>.deduplicate");
+  const queue = new AsyncQueue<Event[]>(`step.${stepName}.deduplicate`);
   const key = [
     options?.["consider-name"] ?? true ? "1" : "0",
     options?.["consider-data"] ?? true ? "1" : "0",

--- a/src/step-functions/keep-when.ts
+++ b/src/step-functions/keep-when.ts
@@ -38,6 +38,7 @@ export const validate = (
  *
  * @param pipelineName The name of the pipeline.
  * @param pipelineSignature The signature of the pipeline.
+ * @param stepName The name of the step this function belongs to.
  * @param options The schema against which the events are matched.
  * @returns A channel that selects events using a schema.
  */
@@ -46,10 +47,11 @@ export const make = async (
   pipelineName: string,
   pipelineSignature: string,
   /* eslint-enable @typescript-eslint/no-unused-vars */
+  stepName: string,
   options: KeepWhenFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   const matchesSchema = ajv.compile(options);
-  const queue = new AsyncQueue<Event[]>("step.<?>.keep-when");
+  const queue = new AsyncQueue<Event[]>(`step.${stepName}.keep-when`);
   return flatMap(
     (events: Event[]) =>
       Promise.resolve(events.filter((event) => matchesSchema(event.data))),

--- a/src/step-functions/keep.ts
+++ b/src/step-functions/keep.ts
@@ -72,6 +72,7 @@ const toInteger = (v: number | string): number =>
  *
  * @param pipelineName The name of the pipeline.
  * @param pipelineSignature The signature of the pipeline.
+ * @param stepName The name of the step this function belongs to.
  * @param options The options that indicate the maximum amount of
  * events to select.
  * @returns A channel that selects events.
@@ -81,6 +82,7 @@ export const make = async (
   pipelineName: string,
   pipelineSignature: string,
   /* eslint-enable @typescript-eslint/no-unused-vars */
+  stepName: string,
   options: KeepFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   const quantity =
@@ -93,7 +95,7 @@ export const make = async (
     typeof options === "string" ||
     typeof options === "number" ||
     "first" in options;
-  const queue = new AsyncQueue<Event[]>("step.<?>.keep");
+  const queue = new AsyncQueue<Event[]>(`step.${stepName}.keep`);
   return flatMap(
     (events: Event[]) =>
       Promise.resolve(

--- a/src/step-functions/rename.ts
+++ b/src/step-functions/rename.ts
@@ -83,6 +83,7 @@ export const validate = (
  *
  * @param pipelineName The name of the pipeline.
  * @param pipelineSignature The signature of the pipeline.
+ * @param stepName The name of the step this function belongs to.
  * @param options The options that indicate how to rename events.
  * @returns A channel that renames its events.
  */
@@ -91,13 +92,14 @@ export const make = async (
   pipelineName: string,
   pipelineSignature: string,
   /* eslint-enable @typescript-eslint/no-unused-vars */
+  stepName: string,
   options: RenameFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   const makeNewName: (name: string) => string =
     "replace" in options
       ? () => options.replace
       : (name) => (options.prepend ?? "") + name + (options.append ?? "");
-  const queue = new AsyncQueue<Event[]>("step.<?>.rename");
+  const queue = new AsyncQueue<Event[]>(`step.${stepName}.rename`);
   return flatMap(
     (events: Event[]) =>
       Promise.all(

--- a/src/step-functions/send-amqp.ts
+++ b/src/step-functions/send-amqp.ts
@@ -12,13 +12,13 @@ import { makeChannel } from "../io/jq";
 const logger = makeLogger("step-functions/send-amqp");
 
 /**
- * Options for this function.
+ * Extended options for this function.
  */
-export interface SendAMQPFunctionOptions {
+interface ExtendedSendAMQPFunctionOptions {
   url: string;
-  exchange: {
-    name: string;
-    type: "direct" | "fanout" | "topic";
+  exchange?: {
+    name?: string;
+    type?: "direct" | "fanout" | "topic";
     durable?: boolean | "true" | "false";
     "auto-delete"?: boolean | "true" | "false";
   };
@@ -28,6 +28,11 @@ export interface SendAMQPFunctionOptions {
   persistent?: boolean | "true" | "false";
   "jq-expr"?: string;
 }
+
+/**
+ * Options for this function.
+ */
+export type SendAMQPFunctionOptions = string | ExtendedSendAMQPFunctionOptions;
 
 /**
  * An ajv schema for the options.
@@ -96,13 +101,19 @@ export const validate = (
 };
 
 /**
+ * Default assertion values for the AMQP exchange.
+ */
+const DEFAULT_EXCHANGE_NAME = "cdp";
+const DEFAULT_EXCHANGE_TYPE = "topic";
+
+/**
  * Function that sends events to an AMQP broker, and forwards the same
  * events to the rest of the pipeline unmodified.
  *
  * @param pipelineName The name of the pipeline.
  * @param pipelineSignature The signature of the pipeline.
- * @param options The options that indicate how to connect and send
- * events to the AMQP broker.
+ * @param variantOptions The options that indicate how to connect and
+ * send events to the AMQP broker.
  * @returns A channel that forwards events to an AMQP broker.
  */
 export const make = async (
@@ -110,11 +121,17 @@ export const make = async (
   pipelineName: string,
   pipelineSignature: string,
   /* eslint-enable @typescript-eslint/no-unused-vars */
-  options: SendAMQPFunctionOptions
+  variantOptions: SendAMQPFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
+  const options: ExtendedSendAMQPFunctionOptions =
+    typeof variantOptions === "string"
+      ? { url: variantOptions }
+      : variantOptions;
   const routingKey =
     options["routing-key"] ??
-    { direct: "cdp", fanout: "", topic: "cdp" }[options.exchange.type];
+    { direct: "cdp", fanout: "", topic: "cdp" }[
+      options.exchange?.type ?? DEFAULT_EXCHANGE_TYPE
+    ];
   const publishOptions = {
     ...(typeof options.expiration !== "undefined"
       ? {
@@ -146,17 +163,17 @@ export const make = async (
   const ch = await conn.createChannel();
   ch.on("error", (err) => logger.error(`Error on AMQP channel: ${err}`));
   const { exchange } = await ch.assertExchange(
-    options.exchange.name,
-    options.exchange.type,
+    options.exchange?.name ?? DEFAULT_EXCHANGE_NAME,
+    options.exchange?.type ?? DEFAULT_EXCHANGE_TYPE,
     {
       durable:
-        typeof options.exchange.durable === "string"
-          ? options.exchange.durable === "true"
-          : options.exchange.durable ?? true,
+        typeof options.exchange?.durable === "string"
+          ? options.exchange?.durable === "true"
+          : options.exchange?.durable ?? true,
       autoDelete:
-        typeof options.exchange["auto-delete"] === "string"
-          ? options.exchange["auto-delete"] === "true"
-          : options.exchange["auto-delete"] ?? false,
+        typeof options.exchange?.["auto-delete"] === "string"
+          ? options.exchange?.["auto-delete"] === "true"
+          : options.exchange?.["auto-delete"] ?? false,
     }
   );
   let forwarder: (events: Event[]) => void;

--- a/src/step-functions/send-receive-http.ts
+++ b/src/step-functions/send-receive-http.ts
@@ -79,6 +79,7 @@ export const validate = (
  *
  * @param pipelineName The name of the pipeline.
  * @param pipelineSignature The signature of the pipeline.
+ * @param stepName The name of the step this function belongs to.
  * @param options The options that indicate how to send events to the
  * remote HTTP endpoint.
  * @returns A channel that uses a remote HTTP endpoint to transform
@@ -87,6 +88,7 @@ export const validate = (
 export const make = async (
   pipelineName: string,
   pipelineSignature: string,
+  stepName: string,
   options: SendReceiveHTTPFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   const target = typeof options === "string" ? options : options.target;
@@ -112,7 +114,7 @@ export const make = async (
       jqChannel
     );
   } else {
-    const queue = new AsyncQueue<Event[]>("step.<?>.send-receive-http");
+    const queue = new AsyncQueue<Event[]>(`step.${stepName}.send-receive-http`);
     return flatMap(
       (events: Event[]) =>
         sendReceiveEvents(

--- a/src/step-functions/send-receive-jq.ts
+++ b/src/step-functions/send-receive-jq.ts
@@ -64,12 +64,16 @@ export const validate = (
  *
  * @param pipelineName The name of the pipeline.
  * @param pipelineSignature The signature of the pipeline.
+ * @param stepName The name of the step this function belongs to.
  * @param options The jq program that transforms events.
  * @returns A channel that transforms events via jq.
  */
 export const make = async (
   pipelineName: string,
   pipelineSignature: string,
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  stepName: string,
+  /* eslint-enable @typescript-eslint/no-unused-vars */
   options: SendReceiveJqFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   const program = typeof options === "string" ? options : options["jq-expr"];


### PR DESCRIPTION
This PR adds a MQTT-using input and step function, provided by [MQTT.js](https://github.com/mqttjs/MQTT.js).

**Included in this PR**:
- A MQTT input form.
- A publish-to-MQTT step function.
- Default values for AMQP exchange name and type, allowing for the options to be optionally collapsed into a string.
- Slightly better debugging with queue names in steps using the name of the step.
- The extension of the composition example with MQTT usage. The [EMQX](https://www.emqx.io/) broker was used for the docker-compose stack.

**Not included**:
- Validation of MQTT connection options.