### PR TITLE
Feature/Fix greedy drains

### DIFF
--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -54,3 +54,31 @@ test("@standalone Environment variables can be replaced in objects", () => {
     "": "this one does, although it may cause trouble",
   });
 });
+
+test("@standalone Fuses can guard a single executor at a time", async () => {
+  // Arrange
+  const openFuse = utils.makeFuse();
+  const triggeredFuse = utils.makeFuse();
+  // Act & assert
+  // Simple guards work if awaited
+  await openFuse.guard((resolve) => setTimeout(resolve, 200));
+  await openFuse.guard((resolve) => setTimeout(resolve, 200));
+  // Multiple guards work if the fuse is triggered in-between guards.
+  const guarded = triggeredFuse.guard((resolve) => {
+    // Never resolve
+  });
+  triggeredFuse.trigger();
+  await Promise.all([
+    guarded,
+    triggeredFuse.guard((resolve) => {
+      // Never resolve
+    }),
+  ]);
+  // Multiple guards fail if awaited on in parallel.
+  await expect(
+    Promise.all([
+      openFuse.guard((resolve) => setTimeout(resolve, 200)),
+      openFuse.guard((resolve) => setTimeout(resolve, 200)),
+    ])
+  ).rejects.toThrow("a previous guard is still in place");
+});

--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -64,13 +64,13 @@ test("@standalone Fuses can guard a single executor at a time", async () => {
   await openFuse.guard((resolve) => setTimeout(resolve, 200));
   await openFuse.guard((resolve) => setTimeout(resolve, 200));
   // Multiple guards work if the fuse is triggered in-between guards.
-  const guarded = triggeredFuse.guard((resolve) => {
+  const guarded = triggeredFuse.guard(() => {
     // Never resolve
   });
   triggeredFuse.trigger();
   await Promise.all([
     guarded,
-    triggeredFuse.guard((resolve) => {
+    triggeredFuse.guard(() => {
       // Never resolve
     }),
   ]);

--- a/src/io/json-processor.ts
+++ b/src/io/json-processor.ts
@@ -163,9 +163,6 @@ export class Processor<Options extends ProcessorOptions = ProcessorOptions> {
     ).asChannel();
     const feedEnded: Promise<void> = (async () => {
       for await (const value of bufferChannel.receive) {
-        if (closedIndependently.value()) {
-          continue;
-        }
         const flushed = child.stdin.write(JSON.stringify(value) + "\n");
         if (!flushed) {
           await closedIndependently.guard((resolve) =>

--- a/src/io/json-processor.ts
+++ b/src/io/json-processor.ts
@@ -3,6 +3,7 @@ import { accessSync, constants, statSync } from "fs";
 import { Readable } from "stream";
 import { AsyncQueue, Channel } from "../async-queue";
 import { PATH } from "../conf";
+import { makeFuse } from "../utils";
 import { parseJson } from "./read-stream";
 
 /**
@@ -141,10 +142,8 @@ export class Processor<Options extends ProcessorOptions = ProcessorOptions> {
     child.on("error", (err) => {
       onError(err);
     });
-    let closedIndependently = false;
-    child.stdin.on("close", () => {
-      closedIndependently = true;
-    });
+    const closedIndependently = makeFuse();
+    child.stdin.on("close", () => closedIndependently.trigger());
     const parseStream = options?.parse ?? parseJson;
     let notifyEnded: () => void;
     const ended: Promise<void> = new Promise((resolve) => {
@@ -164,15 +163,14 @@ export class Processor<Options extends ProcessorOptions = ProcessorOptions> {
     ).asChannel();
     const feedEnded: Promise<void> = (async () => {
       for await (const value of bufferChannel.receive) {
-        if (closedIndependently) {
+        if (closedIndependently.value()) {
           continue;
         }
         const flushed = child.stdin.write(JSON.stringify(value) + "\n");
-        if (!flushed && !closedIndependently) {
-          await Promise.race([
-            new Promise((resolve) => child.stdin.once("drain", resolve)),
-            new Promise((resolve) => child.stdin.once("close", resolve)),
-          ]);
+        if (!flushed) {
+          await closedIndependently.guard((resolve) =>
+            child.stdin.once("drain", resolve)
+          );
         }
       }
     })();

--- a/src/step-functions/send-amqp.ts
+++ b/src/step-functions/send-amqp.ts
@@ -210,7 +210,7 @@ export const make = async (
           "with routing key",
           routingKey
         );
-        if (!flushed && !closed.value()) {
+        if (!flushed) {
           await closed.guard((resolve) => ch.once("drain", resolve));
         }
       }
@@ -239,7 +239,7 @@ export const make = async (
           "with routing key",
           routingKey
         );
-        if (!flushed && !closed.value()) {
+        if (!flushed) {
           await closed.guard((resolve) => ch.once("drain", resolve));
         }
       }

--- a/src/step-functions/send-amqp.ts
+++ b/src/step-functions/send-amqp.ts
@@ -3,7 +3,7 @@ import { match, P } from "ts-pattern";
 import { AsyncQueue, Channel, flatMap, drain } from "../async-queue";
 import { Event } from "../event";
 import { makeLogger } from "../log";
-import { check } from "../utils";
+import { check, makeFuse } from "../utils";
 import { PipelineStepFunctionParameters, makeProcessorChannel } from ".";
 
 /**
@@ -166,11 +166,9 @@ export const make = async (
   const conn = await connect(options.url);
   conn.on("error", (err) => logger.error(`Error on AMQP connection: ${err}`));
   const ch = await conn.createChannel();
-  let closed = false;
   ch.on("error", (err) => logger.error(`Error on AMQP channel: ${err}`));
-  ch.on("close", () => {
-    closed = true;
-  });
+  const closed = makeFuse();
+  ch.on("close", () => closed.trigger());
   const { exchange } = await ch.assertExchange(
     options.exchange?.name ?? DEFAULT_EXCHANGE_NAME,
     options.exchange?.type ?? DEFAULT_EXCHANGE_TYPE,
@@ -212,11 +210,8 @@ export const make = async (
           "with routing key",
           routingKey
         );
-        if (!flushed && !closed) {
-          await Promise.race([
-            new Promise((resolve) => ch.once("drain", resolve)),
-            new Promise((resolve) => ch.once("close", resolve)),
-          ]);
+        if (!flushed && !closed.value()) {
+          await closed.guard((resolve) => ch.once("drain", resolve));
         }
       }
     );
@@ -244,8 +239,8 @@ export const make = async (
           "with routing key",
           routingKey
         );
-        if (!flushed && !closed) {
-          await new Promise((resolve) => ch.once("drain", resolve));
+        if (!flushed && !closed.value()) {
+          await closed.guard((resolve) => ch.once("drain", resolve));
         }
       }
     );

--- a/src/step-functions/send-stdout.ts
+++ b/src/step-functions/send-stdout.ts
@@ -76,7 +76,7 @@ export const make = async (
         const flushed = stdout.write(
           (typeof result === "string" ? result : JSON.stringify(result)) + "\n"
         );
-        if (!flushed && !closed.value()) {
+        if (!flushed) {
           await closed.guard((resolve) => stdout.once("drain", resolve));
         }
       }
@@ -89,7 +89,7 @@ export const make = async (
       async (events: Event[]) => {
         for (const event of events) {
           const flushed = stdout.write(JSON.stringify(event) + "\n");
-          if (!flushed && !closed.value()) {
+          if (!flushed) {
             await closed.guard((resolve) => stdout.once("drain", resolve));
           }
         }

--- a/src/step-functions/send-stdout.ts
+++ b/src/step-functions/send-stdout.ts
@@ -1,7 +1,7 @@
 import { match, P } from "ts-pattern";
 import { Channel, AsyncQueue, flatMap, drain } from "../async-queue";
 import { Event } from "../event";
-import { check } from "../utils";
+import { check, makeFuse } from "../utils";
 import { getSTDOUT } from "../io/stdio";
 import { PipelineStepFunctionParameters, makeProcessorChannel } from ".";
 
@@ -66,10 +66,8 @@ export const make = async (
   options: SendSTDOUTFunctionOptions
 ): Promise<Channel<Event[], Event>> => {
   const stdout = getSTDOUT();
-  let closed = false;
-  stdout.on("close", () => {
-    closed = true;
-  });
+  const closed = makeFuse();
+  stdout.on("close", () => closed.trigger());
   let passThroughChannel: Channel<Event[], never>;
   if (options !== null && typeof options["jq-expr"] === "string") {
     passThroughChannel = drain(
@@ -78,8 +76,8 @@ export const make = async (
         const flushed = stdout.write(
           (typeof result === "string" ? result : JSON.stringify(result)) + "\n"
         );
-        if (!flushed && !closed) {
-          await new Promise((resolve) => stdout.once("drain", resolve));
+        if (!flushed && !closed.value()) {
+          await closed.guard((resolve) => stdout.once("drain", resolve));
         }
       }
     );
@@ -91,11 +89,8 @@ export const make = async (
       async (events: Event[]) => {
         for (const event of events) {
           const flushed = stdout.write(JSON.stringify(event) + "\n");
-          if (!flushed && !closed) {
-            await Promise.race([
-              new Promise((resolve) => stdout.once("drain", resolve)),
-              new Promise((resolve) => stdout.once("close", resolve)),
-            ]);
+          if (!flushed && !closed.value()) {
+            await closed.guard((resolve) => stdout.once("drain", resolve));
           }
         }
       }


### PR DESCRIPTION
This PR fixes an issue with the pattern:

```javascript
await new Promise((resolve) => writable.once("drain", resolve));
```

which fails if `writable` is closed, because the `"drain"` event won't be emitted. The previous PR #18 attempted to solve this by adding a race: `Promise.race(drain, close)`, but that's problematic as well because it schedules the same `"close"` event listener multiple times. **Also**, the use of [Promise.race with long-lasting promises can cause memory problems](https://github.com/nodejs/node/issues/17469).

This PR fixes this following the pointers laid out in the above issue, given by user brainkim.